### PR TITLE
Use a perceptual curve for keyboard volume

### DIFF
--- a/SimuBoardMac/SimuBoardMac/Models/AppSettings.swift
+++ b/SimuBoardMac/SimuBoardMac/Models/AppSettings.swift
@@ -1,12 +1,36 @@
 import Combine
 import Foundation
 
+enum KeyboardVolumeCurve {
+    static let currentVersion = 1
+    static let legacyDefaultGain = 0.42
+
+    static func playbackGain(for sliderPosition: Double) -> Double {
+        let position = clampedUnitValue(sliderPosition)
+        return position * position * position
+    }
+
+    static func sliderPosition(preservingLegacyGain legacyGain: Double) -> Double {
+        Foundation.pow(clampedUnitValue(legacyGain), 1.0 / 3.0)
+    }
+
+    static func normalizedSliderPosition(_ sliderPosition: Double) -> Double {
+        clampedUnitValue(sliderPosition)
+    }
+
+    private static func clampedUnitValue(_ value: Double) -> Double {
+        guard value.isFinite else { return 0 }
+        return min(max(value, 0), 1)
+    }
+}
+
 @MainActor
 final class AppSettings: ObservableObject {
     private enum Key {
         static let enabled = "enabled"
         static let selectedProfile = "selectedProfile"
         static let volume = "volume"
+        static let keyboardVolumeCurveVersion = "keyboardVolumeCurveVersion"
         static let releaseSound = "releaseSound"
         static let pitchVariation = "pitchVariation"
         static let pointerSoundEnabled = "pointerSoundEnabled"
@@ -74,12 +98,27 @@ final class AppSettings: ObservableObject {
         set { selectedPointerProfileID = newValue.rawValue }
     }
 
+    var keyboardPlaybackGain: Double {
+        KeyboardVolumeCurve.playbackGain(for: volume)
+    }
+
     init(defaults: UserDefaults = .standard) {
         self.defaults = defaults
         isEnabled = defaults.object(forKey: Key.enabled) as? Bool ?? true
         selectedProfileID = defaults.string(forKey: Key.selectedProfile) ?? SwitchProfile.holyPanda.rawValue
-        let storedKeyboardVolume = defaults.object(forKey: Key.volume) as? Double ?? 0.42
-        volume = storedKeyboardVolume
+        let storedKeyboardVolume = defaults.object(forKey: Key.volume) as? Double
+        let storedKeyboardVolumeCurveVersion = defaults.integer(forKey: Key.keyboardVolumeCurveVersion)
+        let resolvedKeyboardVolume: Double
+        if let storedKeyboardVolume {
+            resolvedKeyboardVolume = storedKeyboardVolumeCurveVersion < KeyboardVolumeCurve.currentVersion
+                ? KeyboardVolumeCurve.sliderPosition(preservingLegacyGain: storedKeyboardVolume)
+                : KeyboardVolumeCurve.normalizedSliderPosition(storedKeyboardVolume)
+        } else {
+            resolvedKeyboardVolume = KeyboardVolumeCurve.sliderPosition(
+                preservingLegacyGain: KeyboardVolumeCurve.legacyDefaultGain
+            )
+        }
+        volume = resolvedKeyboardVolume
         playsReleaseSound = defaults.object(forKey: Key.releaseSound) as? Bool ?? true
         usesPitchVariation = defaults.object(forKey: Key.pitchVariation) as? Bool ?? true
         isPointerSoundEnabled = defaults.object(forKey: Key.pointerSoundEnabled) as? Bool ?? false
@@ -89,13 +128,20 @@ final class AppSettings: ObservableObject {
             ? PointerSoundProfile.classic.rawValue
             : storedPointerProfileID
         let storedPointerVolume = defaults.object(forKey: Key.pointerVolume) as? Double
-        let resolvedPointerVolume = storedPointerVolume ?? storedKeyboardVolume * 0.65
+        let resolvedPointerVolume = storedPointerVolume
+            ?? KeyboardVolumeCurve.playbackGain(for: resolvedKeyboardVolume) * 0.65
         pointerVolume = min(max(resolvedPointerVolume, 0), 1)
         playsPointerReleaseSound = defaults.object(forKey: Key.pointerReleaseSound) as? Bool ?? true
         isTypingStatsEnabled = defaults.object(forKey: Key.typingStatsEnabled) as? Bool ?? false
         isLaunchAtLoginEnabled = defaults.object(forKey: Key.launchAtLoginEnabled) as? Bool ?? true
         if selectedPointerProfileID != storedPointerProfileID {
             defaults.set(selectedPointerProfileID, forKey: Key.selectedPointerProfile)
+        }
+        if storedKeyboardVolume == nil || storedKeyboardVolume != resolvedKeyboardVolume {
+            defaults.set(resolvedKeyboardVolume, forKey: Key.volume)
+        }
+        if storedKeyboardVolumeCurveVersion < KeyboardVolumeCurve.currentVersion {
+            defaults.set(KeyboardVolumeCurve.currentVersion, forKey: Key.keyboardVolumeCurveVersion)
         }
         if storedPointerVolume == nil || storedPointerVolume != pointerVolume {
             defaults.set(pointerVolume, forKey: Key.pointerVolume)

--- a/SimuBoardMac/SimuBoardMac/Models/AppSettings.swift
+++ b/SimuBoardMac/SimuBoardMac/Models/AppSettings.swift
@@ -52,7 +52,10 @@ final class AppSettings: ObservableObject {
     }
 
     @Published var volume: Double {
-        didSet { defaults.set(volume, forKey: Key.volume) }
+        didSet {
+            defaults.set(volume, forKey: Key.volume)
+            defaults.set(KeyboardVolumeCurve.currentVersion, forKey: Key.keyboardVolumeCurveVersion)
+        }
     }
 
     @Published var playsReleaseSound: Bool {

--- a/SimuBoardMac/SimuBoardMac/Services/AppModel.swift
+++ b/SimuBoardMac/SimuBoardMac/Services/AppModel.swift
@@ -278,14 +278,14 @@ final class AppModel: ObservableObject {
         audioEngine.play(
             keyCode: keyCode,
             phase: phase,
-            volume: settings.volume,
+            volume: settings.keyboardPlaybackGain,
             pitchVariation: settings.usesPitchVariation
         )
         syncAudioError()
     }
 
     func preview(audioAt url: URL) {
-        audioEngine.preview(audioAt: url, volume: settings.volume)
+        audioEngine.preview(audioAt: url, volume: settings.keyboardPlaybackGain)
         syncAudioError()
     }
 
@@ -336,7 +336,7 @@ final class AppModel: ObservableObject {
             audioEngine.play(
                 keyCode: event.keyCode,
                 phase: phase,
-                volume: settings.volume,
+                volume: settings.keyboardPlaybackGain,
                 pitchVariation: settings.usesPitchVariation
             )
             syncAudioError()

--- a/SimuBoardMac/SimuBoardMac/Views/MenuBarView.swift
+++ b/SimuBoardMac/SimuBoardMac/Views/MenuBarView.swift
@@ -238,7 +238,7 @@ struct MenuBarView: View {
                 HStack {
                     Text("键盘绝对音量")
                     Spacer()
-                    Text("\(Int(settings.volume * 100))%")
+                    Text("\(Int(settings.keyboardPlaybackGain * 100))%")
                         .monospacedDigit()
                         .foregroundStyle(.secondary)
                 }

--- a/SimuBoardMac/Tests/DIYCoreHarness.swift
+++ b/SimuBoardMac/Tests/DIYCoreHarness.swift
@@ -289,6 +289,7 @@ private struct DIYCoreHarness {
             try testSemanticVersion(&results)
             try testKeyboardVisualLayout(&results)
             try testPointerEventMapping(&results)
+            try testPerceptualKeyboardVolume(&results)
             try testPointerSettingsAndResources(&results)
             try testLaunchAtLoginInstallPaths(&results)
             try testValidatorAndResolver(&results)
@@ -301,6 +302,45 @@ private struct DIYCoreHarness {
         } catch {
             fputs("DIY core harness FAILED: \(error)\n", stderr)
             exit(1)
+        }
+    }
+
+    private static func testPerceptualKeyboardVolume(
+        _ results: inout HarnessResults
+    ) throws {
+        let fixtures: [(position: Double, expectedGain: Double)] = [
+            (0, 0),
+            (0.25, 0.015_625),
+            (0.5, 0.125),
+            (0.75, 0.421_875),
+            (1, 1),
+        ]
+
+        for fixture in fixtures {
+            try results.check(
+                abs(
+                    KeyboardVolumeCurve.playbackGain(for: fixture.position)
+                        - fixture.expectedGain
+                ) < 0.000_001,
+                "keyboard slider position \(fixture.position) should use cubic gain"
+            )
+        }
+
+        try results.check(
+            KeyboardVolumeCurve.playbackGain(for: -1) == 0
+                && KeyboardVolumeCurve.playbackGain(for: 2) == 1,
+            "keyboard gain should clamp positions to the slider range"
+        )
+
+        for legacyGain in [0.0, 0.01, 0.42, 0.8, 1.0] {
+            let migratedPosition = KeyboardVolumeCurve.sliderPosition(
+                preservingLegacyGain: legacyGain
+            )
+            try results.check(
+                abs(KeyboardVolumeCurve.playbackGain(for: migratedPosition) - legacyGain)
+                    < 0.000_001,
+                "legacy gain \(legacyGain) should survive perceptual-curve migration"
+            )
         }
     }
 
@@ -532,6 +572,22 @@ private struct DIYCoreHarness {
         try results.check(initial.selectedPointerProfile == .classic, "classic should be the default pointer profile")
         try results.check(initial.playsPointerReleaseSound, "pointer release sound should default to enabled")
         try results.check(
+            abs(initial.keyboardPlaybackGain - 0.42) < 0.000_001,
+            "a new install should preserve the legacy default audible keyboard gain"
+        )
+        try results.check(
+            abs(
+                initial.volume
+                    - KeyboardVolumeCurve.sliderPosition(preservingLegacyGain: 0.42)
+            ) < 0.000_001,
+            "a new install should expose the legacy default through the perceptual slider"
+        )
+        try results.check(
+            defaults.integer(forKey: "keyboardVolumeCurveVersion")
+                == KeyboardVolumeCurve.currentVersion,
+            "a new install should persist the current keyboard volume representation"
+        )
+        try results.check(
             abs(initial.pointerVolume - (0.42 * 0.65)) < 0.000_001,
             "a new pointer volume should start at 65% of the keyboard volume"
         )
@@ -574,6 +630,18 @@ private struct DIYCoreHarness {
         defer { migrationDefaults.removePersistentDomain(forName: migrationSuiteName) }
         migrationDefaults.set(0.8, forKey: "volume")
         let migrated = AppSettings(defaults: migrationDefaults)
+        let migratedPosition = KeyboardVolumeCurve.sliderPosition(preservingLegacyGain: 0.8)
+        try results.check(
+            abs(migrated.volume - migratedPosition) < 0.000_001
+                && abs(migrated.keyboardPlaybackGain - 0.8) < 0.000_001,
+            "a legacy keyboard volume should migrate to the cubic slider without changing gain"
+        )
+        try results.check(
+            abs(migrationDefaults.double(forKey: "volume") - migratedPosition) < 0.000_001
+                && migrationDefaults.integer(forKey: "keyboardVolumeCurveVersion")
+                    == KeyboardVolumeCurve.currentVersion,
+            "keyboard volume migration should persist its position and version"
+        )
         try results.check(
             abs(migrated.pointerVolume - 0.52) < 0.000_001,
             "an existing keyboard volume should seed pointer volume at 65% exactly once"
@@ -582,8 +650,9 @@ private struct DIYCoreHarness {
         let migratedReloaded = AppSettings(defaults: migrationDefaults)
         try results.check(
             abs(migratedReloaded.volume - 0.4) < 0.000_001
+                && abs(migratedReloaded.keyboardPlaybackGain - 0.064) < 0.000_001
                 && abs(migratedReloaded.pointerVolume - 0.52) < 0.000_001,
-            "changing keyboard volume after migration must not change pointer volume"
+            "the curve must migrate once while pointer volume remains independent"
         )
 
         let projectRoot = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
@@ -1268,14 +1337,28 @@ private struct DIYCoreHarness {
         let keyboardHandlerSource = appModelSource[keyboardHandlerStart..<pointerHandlerStart]
         let pointerHandlerSource = appModelSource[pointerHandlerStart..<pointerHandlerEnd]
         try results.check(
-            keyboardHandlerSource.contains("volume: settings.volume")
+            keyboardHandlerSource.contains("volume: settings.keyboardPlaybackGain")
                 && !keyboardHandlerSource.contains("settings.pointerVolume"),
-            "keyboard events must use only the keyboard volume"
+            "keyboard events must use the perceptual keyboard gain"
         )
         try results.check(
             pointerHandlerSource.contains("volume: settings.pointerVolume")
                 && !pointerHandlerSource.contains("volume: settings.volume"),
             "pointer events must use only the pointer volume"
+        )
+
+        guard let previewStart = appModelSource.range(of: "    func preview()")?.lowerBound,
+              let monitorStart = appModelSource.range(
+                  of: "    private func startKeyboardMonitor()",
+                  range: previewStart..<appModelSource.endIndex
+              )?.lowerBound else {
+            throw HarnessFailure.assertion("could not isolate keyboard preview routing")
+        }
+        let previewSource = appModelSource[previewStart..<monitorStart]
+        try results.check(
+            previewSource.contains("volume: settings.keyboardPlaybackGain")
+                && !previewSource.contains("volume: settings.volume"),
+            "keyboard previews must use the perceptual keyboard gain"
         )
     }
 

--- a/docs/plans/2026-08-24-perceptual-keyboard-volume-design.md
+++ b/docs/plans/2026-08-24-perceptual-keyboard-volume-design.md
@@ -1,0 +1,37 @@
+# Perceptual Keyboard Volume Design
+
+## Goal
+
+Give the keyboard-volume slider useful precision at quiet levels while preserving Battuta's existing audible level during upgrade. The macOS absolute-volume compensation remains independent and continues to operate in decibels.
+
+## Decision
+
+Treat the keyboard slider as a perceptual control position rather than a linear amplitude. Convert its `0...1` position to playback gain with a cubic taper:
+
+```text
+gain = position ^ 3
+```
+
+This follows the cubic UI taper used by mature audio stacks such as Qt, OBS, and PulseAudio. It is continuous at silence, keeps full scale at `100%`, and gives substantially more travel to quiet levels without the complexity of a professional IEC fader. Pointer volume remains linear and unchanged.
+
+## Settings Migration
+
+Version the keyboard-volume representation in `UserDefaults`. Existing stored values are linear gains, so migrate them exactly once with:
+
+```text
+newPosition = cubeRoot(oldLinearGain)
+```
+
+After migration, `newPosition ^ 3 == oldLinearGain`, preserving audible output. The legacy default gain of `0.42` therefore becomes a slider position of about `0.749`. New installs use the same perceptual position and audible default. Pointer-volume seeding continues to use the keyboard's resolved linear gain, so its behavior does not change.
+
+## Data Flow
+
+`AppSettings.volume` stores and displays the perceptual slider position. A read-only `keyboardPlaybackGain` converts that position to linear gain. All keyboard playback and previews pass this converted gain to `KeyboardAudioEngine`; pointer playback continues to pass `pointerVolume` directly. The existing Core Audio scalar-to-decibel lookup and inverse compensation stages are untouched.
+
+## Tests
+
+- Prove the cubic curve at silence, quarter, half, three-quarter, and full positions.
+- Prove legacy volume migration preserves linear gain and runs only once.
+- Prove the default audible level and pointer default remain unchanged.
+- Prove keyboard and preview routes use `keyboardPlaybackGain` while pointer routing remains linear.
+- Run every native core harness and a Release Xcode build before installing locally.

--- a/docs/plans/2026-08-24-perceptual-keyboard-volume.md
+++ b/docs/plans/2026-08-24-perceptual-keyboard-volume.md
@@ -1,0 +1,42 @@
+# Perceptual Keyboard Volume Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Replace Battuta's linear keyboard slider mapping with a cubic perceptual taper while preserving every existing user's audible volume across upgrade.
+
+**Architecture:** `AppSettings.volume` remains the UI position. Pure curve helpers expose cubic playback gain and inverse legacy migration; a versioned `UserDefaults` migration runs once. `AppModel` passes only the converted keyboard gain to keyboard and preview playback, while the pointer path and Core Audio compensation remain unchanged.
+
+**Tech Stack:** Swift 6, SwiftUI, Combine, Foundation/UserDefaults, AVFAudio, zsh core harnesses, Xcode.
+
+---
+
+### Task 1: Define the curve and migration contract
+
+**Files:**
+- Modify: `SimuBoardMac/Tests/DIYCoreHarness.swift`
+
+1. Add assertions for cubic gain values, inverse migration, the migrated legacy default, one-time persistence, and unchanged pointer seeding.
+2. Add source-contract assertions that all keyboard and preview paths use `settings.keyboardPlaybackGain`, while pointer playback still uses `settings.pointerVolume`.
+3. Run `SimuBoardMac/Tests/run-diy-core-harness.sh`; verify the new assertions fail because the curve API and migration do not exist.
+
+### Task 2: Implement the perceptual keyboard control
+
+**Files:**
+- Modify: `SimuBoardMac/SimuBoardMac/Models/AppSettings.swift`
+- Modify: `SimuBoardMac/SimuBoardMac/Services/AppModel.swift`
+
+1. Add a pure cubic `KeyboardVolumeCurve` with clamped forward and inverse conversions.
+2. Add a version key and migrate legacy linear values with the inverse curve exactly once.
+3. Expose `keyboardPlaybackGain` and seed missing pointer volume from that linear gain.
+4. Pass `keyboardPlaybackGain` to keyboard playback and previews; leave pointer playback unchanged.
+5. Run the DIY harness and confirm it passes.
+
+### Task 3: Verify and deliver
+
+**Files:**
+- Modify only if verification exposes a defect.
+
+1. Run all five native core harnesses.
+2. Run a clean Release Xcode build.
+3. Inspect the diff and commit the feature.
+4. Push the feature branch, install the built app locally, relaunch it, and verify the running bundle and version.


### PR DESCRIPTION
## Summary
- migrate keyboard volume storage from linear gain to a cubic perceptual slider while preserving existing audible levels
- route keyboard playback and preview through the perceptual gain, and keep pointer volume behavior unchanged
- show the effective keyboard gain in the menu bar and document the design/implementation notes

## Test Plan
- ./Tests/run-diy-core-harness.sh
- ./Tests/run-absolute-volume-core-harness.sh
- ./Tests/run-audio-variant-core-harness.sh
- ./Tests/run-typing-stats-core-harness.sh
- ./Tests/run-update-installer-core-harness.sh
- xcodebuild -project SimuBoardMac.xcodeproj -scheme SimuBoardMac -configuration Release -derivedDataPath build/DerivedData build