### PR TITLE
Improve history statistics performance

### DIFF
--- a/SimuBoardMac/SimuBoardMac/Views/TypingStatsReportView.swift
+++ b/SimuBoardMac/SimuBoardMac/Views/TypingStatsReportView.swift
@@ -8,7 +8,7 @@ private struct TypingReportRequest: Hashable {
     let comparisonEndDate: Date?
 }
 
-private enum TypingRhythmMode: String, CaseIterable, Identifiable {
+private enum TypingRhythmMode: String, CaseIterable, Identifiable, Equatable {
     case current = "当前"
     case difference = "差异"
 
@@ -65,6 +65,9 @@ struct TypingStatsHistoryView: View {
     var body: some View {
         GeometryReader { geometry in
             let heatmapMetrics = heatmapMetrics(for: geometry.size.width)
+            let usesHorizontalTopPanels = usesHorizontalTopPanels(
+                for: geometry.size.width
+            )
 
             ScrollView {
                 VStack(alignment: .leading, spacing: 16) {
@@ -73,7 +76,11 @@ struct TypingStatsHistoryView: View {
                     }
 
                     if let report = model.reportSnapshot {
-                        reportContent(report, heatmapMetrics: heatmapMetrics)
+                        reportContent(
+                            report,
+                            heatmapMetrics: heatmapMetrics,
+                            usesHorizontalTopPanels: usesHorizontalTopPanels
+                        )
                             .opacity(model.isLoadingReport ? 0.62 : 1)
                             .overlay {
                                 if model.isLoadingReport {
@@ -127,12 +134,13 @@ struct TypingStatsHistoryView: View {
     @ViewBuilder
     private func reportContent(
         _ report: TypingRangeReportSnapshot,
-        heatmapMetrics: TypingHeatmapCellMetrics
+        heatmapMetrics: TypingHeatmapCellMetrics,
+        usesHorizontalTopPanels: Bool
     ) -> some View {
         let topPanelHeight = 144 + heatmapMetrics.cellSize * 7
 
         VStack(alignment: .leading, spacing: 16) {
-            ViewThatFits(in: .horizontal) {
+            if usesHorizontalTopPanels {
                 HStack(alignment: .top, spacing: 16) {
                     rhythmChanges(
                         report,
@@ -143,7 +151,7 @@ struct TypingStatsHistoryView: View {
                     applicationChanges(report, panelHeight: topPanelHeight)
                         .frame(minWidth: 400, maxWidth: 470, alignment: .topLeading)
                 }
-
+            } else {
                 VStack(alignment: .leading, spacing: 16) {
                     rhythmChanges(
                         report,
@@ -160,6 +168,7 @@ struct TypingStatsHistoryView: View {
                 calendar: calendar,
                 metrics: heatmapMetrics
             )
+            .equatable()
             .padding(16)
             .historyInstrumentPanel()
 
@@ -179,6 +188,11 @@ struct TypingStatsHistoryView: View {
             cellSize: cellSize,
             spacing: TypingHeatmapCellMetrics.spacing
         )
+    }
+
+    private func usesHorizontalTopPanels(for viewportWidth: CGFloat) -> Bool {
+        let contentWidth = min(1_080, max(0, viewportWidth)) - 40
+        return contentWidth >= 530 + 16 + 400
     }
 
     private func reportOverviewStrip(_ report: TypingRangeReportSnapshot) -> some View {
@@ -314,6 +328,7 @@ struct TypingStatsHistoryView: View {
                 } ?? [:],
                 metrics: heatmapMetrics
             )
+            .equatable()
 
             rhythmLegend(hasComparison: report.comparisonRange != nil)
         }
@@ -847,7 +862,8 @@ struct TypingStatsHistoryView: View {
     }
 }
 
-private struct TypingWeekdayHourHeatmap: View {
+@MainActor
+private struct TypingWeekdayHourHeatmap: View, Equatable {
     let values: [TypingWeekdayHourAggregate]
     let mode: TypingRhythmMode
     let currentWeekdayOccurrences: [Int: Int]
@@ -856,19 +872,15 @@ private struct TypingWeekdayHourHeatmap: View {
 
     private let weekdays = [2, 3, 4, 5, 6, 7, 1]
 
-    private var valuesByID: [Int: TypingWeekdayHourAggregate] {
-        Dictionary(uniqueKeysWithValues: values.map { ($0.id, $0) })
-    }
-
-    private var maximumCurrent: Double {
-        values.map(currentAverage).max() ?? 0
-    }
-
-    private var maximumDifference: Double {
-        values.map { abs(significantDifference(for: $0)) }.max() ?? 0
-    }
-
     var body: some View {
+        let valuesByID = Dictionary(uniqueKeysWithValues: values.map { ($0.id, $0) })
+        let maximumCurrent = values.lazy.map { currentAverage($0) }.max() ?? 0
+        let maximumDifference = values.lazy.map {
+            abs(significantDifference(for: $0))
+        }.max() ?? 0
+        let exposesEmptyCellsToAssistiveTech = NSWorkspace.shared.isVoiceOverEnabled
+            || NSWorkspace.shared.isSwitchControlEnabled
+
         Grid(
             alignment: .center,
             horizontalSpacing: metrics.spacing,
@@ -901,13 +913,17 @@ private struct TypingWeekdayHourHeatmap: View {
 
                     ForEach(0..<24, id: \.self) { hour in
                         let id = (weekday - 1) * 24 + hour
+                        let value = valuesByID[id] ?? TypingWeekdayHourAggregate(
+                            weekday: weekday,
+                            hour: hour,
+                            characterCount: 0,
+                            comparisonCharacterCount: 0
+                        )
                         rhythmCell(
-                            valuesByID[id] ?? TypingWeekdayHourAggregate(
-                                weekday: weekday,
-                                hour: hour,
-                                characterCount: 0,
-                                comparisonCharacterCount: 0
-                            )
+                            value,
+                            maximumCurrent: maximumCurrent,
+                            maximumDifference: maximumDifference,
+                            exposesEmptyCellsToAssistiveTech: exposesEmptyCellsToAssistiveTech
                         )
                     }
                 }
@@ -916,7 +932,12 @@ private struct TypingWeekdayHourHeatmap: View {
         .frame(maxWidth: .infinity, alignment: .leading)
     }
 
-    private func rhythmCell(_ value: TypingWeekdayHourAggregate) -> some View {
+    private func rhythmCell(
+        _ value: TypingWeekdayHourAggregate,
+        maximumCurrent: Double,
+        maximumDifference: Double,
+        exposesEmptyCellsToAssistiveTech: Bool
+    ) -> some View {
         let delta = significantDifference(for: value)
         let color: Color
         let opacity: Double
@@ -946,7 +967,7 @@ private struct TypingWeekdayHourHeatmap: View {
             }
         }
 
-        return Text(symbol)
+        let content = Text(symbol)
             .font(.system(size: max(6, metrics.cellSize * 0.62), weight: .semibold))
             .foregroundStyle(Color.white.opacity(mode == .difference && delta == 0 ? 0.42 : 0.90))
             .frame(width: metrics.cellSize, height: metrics.cellSize)
@@ -957,11 +978,26 @@ private struct TypingWeekdayHourHeatmap: View {
             .overlay {
                 RoundedRectangle(cornerRadius: 2, style: .continuous)
                     .stroke(Color.white.opacity(0.035), lineWidth: 1)
+        }
+
+        let hasInput = value.characterCount > 0 || value.comparisonCharacterCount > 0
+        let detail = hasInput || exposesEmptyCellsToAssistiveTech ? detailText(value) : ""
+        return Group {
+            if hasInput {
+                content
+                    .help(detail)
+                    .accessibilityElement(children: .ignore)
+                    .accessibilityLabel("\(weekdayTitle(value.weekday)) \(value.hour) 点")
+                    .accessibilityValue(detail)
+            } else if exposesEmptyCellsToAssistiveTech {
+                content
+                    .accessibilityElement(children: .ignore)
+                    .accessibilityLabel("\(weekdayTitle(value.weekday)) \(value.hour) 点")
+                    .accessibilityValue(detail)
+            } else {
+                content.accessibilityHidden(true)
             }
-            .help(helpText(value))
-            .accessibilityElement(children: .ignore)
-            .accessibilityLabel("\(weekdayTitle(value.weekday)) \(value.hour) 点")
-            .accessibilityValue(helpText(value))
+        }
     }
 
     private func normalized(_ value: Double, maximum: Double) -> Double {
@@ -992,7 +1028,7 @@ private struct TypingWeekdayHourHeatmap: View {
         return ["周日", "周一", "周二", "周三", "周四", "周五", "周六"][weekday - 1]
     }
 
-    private func helpText(_ value: TypingWeekdayHourAggregate) -> String {
+    private func detailText(_ value: TypingWeekdayHourAggregate) -> String {
         let hour = String(format: "%02d:00–%02d:00", value.hour, (value.hour + 1) % 24)
         if mode == .current {
             return "\(weekdayTitle(value.weekday)) \(hour)：合计 \(statsCount(value.characterCount))，每个该星期平均 \(averageText(currentAverage(value))) 个字符"
@@ -1010,14 +1046,27 @@ private struct TypingWeekdayHourHeatmap: View {
 }
 
 @MainActor
+private enum TypingReportApplicationIconCache {
+    private static var icons: [String: NSImage] = [:]
+
+    static func icon(for bundleIdentifier: String) -> NSImage? {
+        if let cached = icons[bundleIdentifier] { return cached }
+        guard let url = NSWorkspace.shared.urlForApplication(withBundleIdentifier: bundleIdentifier) else {
+            return nil
+        }
+        let icon = NSWorkspace.shared.icon(forFile: url.path)
+        icons[bundleIdentifier] = icon
+        return icon
+    }
+}
+
+@MainActor
 private struct TypingReportApplicationIcon: View {
     let application: TypingApplicationIdentity
 
     private var applicationIcon: NSImage? {
-        guard let bundleIdentifier = application.bundleIdentifier,
-              let url = NSWorkspace.shared.urlForApplication(withBundleIdentifier: bundleIdentifier)
-        else { return nil }
-        return NSWorkspace.shared.icon(forFile: url.path)
+        guard let bundleIdentifier = application.bundleIdentifier else { return nil }
+        return TypingReportApplicationIconCache.icon(for: bundleIdentifier)
     }
 
     var body: some View {

--- a/SimuBoardMac/SimuBoardMac/Views/TypingStatsView.swift
+++ b/SimuBoardMac/SimuBoardMac/Views/TypingStatsView.swift
@@ -1,12 +1,17 @@
 import Charts
 import SwiftUI
 
-private enum TypingStatsSection: String, CaseIterable, Identifiable {
+private enum TypingStatsSection: String, CaseIterable, Identifiable, Hashable {
     case today = "今日"
     case history = "历史"
     case keyboard = "键盘"
 
     var id: Self { self }
+}
+
+private struct TypingStatsRefreshTask: Hashable {
+    let section: TypingStatsSection
+    let timelineRange: TypingTimelineRange
 }
 
 @MainActor
@@ -35,8 +40,16 @@ struct TypingStatsView: View {
         .frame(minWidth: 820, idealWidth: 1_040, minHeight: 600, idealHeight: 760)
         .battutaWindowGlass()
         .tint(BattutaVisualStyle.actionAccent)
-        .task(id: model.timelineRange) {
-            await refreshWhileVisible(range: model.timelineRange)
+        .task(
+            id: TypingStatsRefreshTask(
+                section: selectedSection,
+                timelineRange: model.timelineRange
+            )
+        ) {
+            await refreshWhileVisible(
+                section: selectedSection,
+                range: model.timelineRange
+            )
         }
         .alert("清除全部输入统计？", isPresented: $showsClearConfirmation) {
             Button("取消", role: .cancel) {}
@@ -240,8 +253,16 @@ struct TypingStatsView: View {
         .monospacedDigit()
     }
 
-    private func refreshWhileVisible(range: TypingTimelineRange) async {
+    private func refreshWhileVisible(
+        section: TypingStatsSection,
+        range: TypingTimelineRange
+    ) async {
         await model.refresh()
+        // The history page owns its one-off annual report refresh. Keeping the
+        // today-page polling loop alive here needlessly rebuilt the full 365-day
+        // chart every few seconds while the user was reading or scrolling it.
+        guard section != .history else { return }
+
         while !Task.isCancelled {
             do {
                 try await Task.sleep(
@@ -250,6 +271,9 @@ struct TypingStatsView: View {
             } catch is CancellationError {
                 return
             } catch {
+                return
+            }
+            guard selectedSection == section, model.timelineRange == range else {
                 return
             }
             await model.refresh()

--- a/SimuBoardMac/SimuBoardMac/Views/TypingYearHeatmap.swift
+++ b/SimuBoardMac/SimuBoardMac/Views/TypingYearHeatmap.swift
@@ -1,3 +1,4 @@
+import AppKit
 import Foundation
 import SwiftUI
 
@@ -29,11 +30,10 @@ struct TypingHeatmapCellMetrics: Equatable, Sendable {
 ///
 /// The caller owns the surrounding panel so this view can be composed with the
 /// history page's existing instrument-card treatment.
-struct TypingYearHeatmap: View {
-    let range: TypingDateRange
-    let days: [TypingDaySummary]
-    let calendar: Calendar
-    let preferredMetrics: TypingHeatmapCellMetrics
+@MainActor
+struct TypingYearHeatmap: View, Equatable {
+    private let presentation: TypingYearHeatmapPresentation
+    private let preferredMetrics: TypingHeatmapCellMetrics
 
     private let weekdayLabels = ["一", "", "三", "", "五", "", ""]
 
@@ -44,9 +44,11 @@ struct TypingYearHeatmap: View {
         cellSize: CGFloat = TypingHeatmapCellMetrics.standard.cellSize,
         cellSpacing: CGFloat = TypingHeatmapCellMetrics.standard.spacing
     ) {
-        self.range = range
-        self.days = days
-        self.calendar = calendar
+        presentation = TypingYearHeatmapPresentation(
+            range: range,
+            days: days,
+            calendar: calendar
+        )
         preferredMetrics = TypingHeatmapCellMetrics(
             cellSize: cellSize,
             spacing: cellSpacing
@@ -59,124 +61,59 @@ struct TypingYearHeatmap: View {
         calendar: Calendar,
         metrics: TypingHeatmapCellMetrics
     ) {
-        self.range = range
-        self.days = days
-        self.calendar = calendar
+        presentation = TypingYearHeatmapPresentation(
+            range: range,
+            days: days,
+            calendar: calendar
+        )
         preferredMetrics = metrics
     }
 
-    private var startDate: Date {
-        calendar.startOfDay(for: range.startDate)
-    }
-
-    private var endDate: Date {
-        calendar.startOfDay(for: range.endDate)
-    }
-
-    /// The first visible column always begins on Monday.
-    private var gridStartDate: Date {
-        calendar.date(
-            byAdding: .day,
-            value: -mondayBasedWeekdayIndex(for: startDate),
-            to: startDate
-        ) ?? startDate
-    }
-
-    /// The final visible column always ends on Sunday.
-    private var gridEndDate: Date {
-        let remainingDays = 6 - mondayBasedWeekdayIndex(for: endDate)
-        return calendar.date(byAdding: .day, value: remainingDays, to: endDate) ?? endDate
-    }
-
-    private var weekCount: Int {
-        let dayCount = calendar.dateComponents(
-            [.day],
-            from: gridStartDate,
-            to: gridEndDate
-        ).day ?? 0
-        return max(1, dayCount / 7 + 1)
-    }
-
-    private var summariesByDate: [Date: TypingDaySummary] {
-        days.reduce(into: [:]) { result, summary in
-            result[calendar.startOfDay(for: summary.date)] = summary
-        }
-    }
-
-    private var maximumCount: Int64 {
-        days.lazy
-            .filter { summary in
-                let date = calendar.startOfDay(for: summary.date)
-                return date >= startDate && date <= endDate
-            }
-            .map(\.characterCount)
-            .max() ?? 0
-    }
-
-    private var monthMarkers: [MonthMarker] {
-        var markers: [MonthMarker] = []
-        var cursor = startDate
-        var previousMonth: Int?
-        var previousYear: Int?
-
-        while cursor <= endDate {
-            let month = calendar.component(.month, from: cursor)
-            let year = calendar.component(.year, from: cursor)
-            if month != previousMonth || year != previousYear {
-                let dayOffset = calendar.dateComponents(
-                    [.day],
-                    from: gridStartDate,
-                    to: cursor
-                ).day ?? 0
-                markers.append(
-                    MonthMarker(
-                        date: cursor,
-                        weekIndex: max(0, dayOffset / 7)
-                    )
-                )
-                previousMonth = month
-                previousYear = year
-            }
-
-            guard let next = calendar.date(byAdding: .day, value: 1, to: cursor), next > cursor else {
-                break
-            }
-            cursor = next
-        }
-
-        return markers
-    }
-
     var body: some View {
+        let exposesEmptyCellsToAssistiveTech = NSWorkspace.shared.isVoiceOverEnabled
+            || NSWorkspace.shared.isSwitchControlEnabled
+
         VStack(alignment: .leading, spacing: 14) {
             VStack(alignment: .leading, spacing: 3) {
                 Text("全年输入热力图")
                     .font(.headline.weight(.semibold))
                     .foregroundStyle(BattutaVisualStyle.instrumentPrimary)
 
-                Text("\(rangeDescription) · 每个方格代表一天，颜色越亮表示输入越多")
+                Text("\(presentation.rangeDescription) · 每个方格代表一天，颜色越亮表示输入越多")
                     .font(.caption)
                     .foregroundStyle(BattutaVisualStyle.instrumentSecondary)
             }
 
-            heatmapContent(metrics: preferredMetrics)
+            heatmapContent(
+                presentation: presentation,
+                metrics: preferredMetrics,
+                exposesEmptyCellsToAssistiveTech: exposesEmptyCellsToAssistiveTech
+            )
                 .frame(maxWidth: .infinity, alignment: .leading)
         }
         .frame(maxWidth: .infinity, alignment: .leading)
     }
 
-    private func heatmapContent(metrics: TypingHeatmapCellMetrics) -> some View {
+    private func heatmapContent(
+        presentation: TypingYearHeatmapPresentation,
+        metrics: TypingHeatmapCellMetrics,
+        exposesEmptyCellsToAssistiveTech: Bool
+    ) -> some View {
         let totalWidth = weekdayLabelWidth(metrics)
             + labelGridSpacing(metrics)
-            + gridWidth(metrics)
+            + gridWidth(presentation: presentation, metrics: metrics)
 
         return VStack(alignment: .leading, spacing: 12 * scale(metrics)) {
             HStack(alignment: .top, spacing: labelGridSpacing(metrics)) {
                 weekdayAxis(metrics: metrics)
 
                 VStack(alignment: .leading, spacing: 5 * scale(metrics)) {
-                    monthAxis(metrics: metrics)
-                    contributionGrid(metrics: metrics)
+                    monthAxis(presentation: presentation, metrics: metrics)
+                    contributionGrid(
+                        presentation: presentation,
+                        metrics: metrics,
+                        exposesEmptyCellsToAssistiveTech: exposesEmptyCellsToAssistiveTech
+                    )
                 }
             }
 
@@ -208,13 +145,19 @@ struct TypingYearHeatmap: View {
         }
     }
 
-    private func monthAxis(metrics: TypingHeatmapCellMetrics) -> some View {
+    private func monthAxis(
+        presentation: TypingYearHeatmapPresentation,
+        metrics: TypingHeatmapCellMetrics
+    ) -> some View {
         ZStack(alignment: .topLeading) {
             Color.clear
-                .frame(width: gridWidth(metrics), height: 12 * scale(metrics))
+                .frame(
+                    width: gridWidth(presentation: presentation, metrics: metrics),
+                    height: 12 * scale(metrics)
+                )
 
-            ForEach(monthMarkers) { marker in
-                Text(monthTitle(marker.date))
+            ForEach(presentation.monthMarkers) { marker in
+                Text(marker.title)
                     .font(.system(size: max(6, 9 * scale(metrics)), weight: .medium))
                     .foregroundStyle(BattutaVisualStyle.instrumentSecondary)
                     .fixedSize()
@@ -222,19 +165,27 @@ struct TypingYearHeatmap: View {
                     .accessibilityHidden(true)
             }
         }
-        .frame(width: gridWidth(metrics), height: 12 * scale(metrics))
+        .frame(
+            width: gridWidth(presentation: presentation, metrics: metrics),
+            height: 12 * scale(metrics)
+        )
     }
 
-    private func contributionGrid(metrics: TypingHeatmapCellMetrics) -> some View {
+    private func contributionGrid(
+        presentation: TypingYearHeatmapPresentation,
+        metrics: TypingHeatmapCellMetrics,
+        exposesEmptyCellsToAssistiveTech: Bool
+    ) -> some View {
         HStack(alignment: .top, spacing: metrics.spacing) {
-            ForEach(0..<weekCount, id: \.self) { weekIndex in
+            ForEach(presentation.weeks) { week in
                 VStack(spacing: metrics.spacing) {
-                    ForEach(0..<7, id: \.self) { weekdayIndex in
-                        if let date = date(weekIndex: weekIndex, weekdayIndex: weekdayIndex),
-                           date >= startDate,
-                           date <= endDate
-                        {
-                            dayCell(date, metrics: metrics)
+                    ForEach(week.cells) { cell in
+                        if cell.isVisible {
+                            dayCell(
+                                cell,
+                                metrics: metrics,
+                                exposesEmptyCellsToAssistiveTech: exposesEmptyCellsToAssistiveTech
+                            )
                         } else {
                             Color.clear
                                 .frame(width: metrics.cellSize, height: metrics.cellSize)
@@ -244,28 +195,46 @@ struct TypingYearHeatmap: View {
                 }
             }
         }
-        .frame(width: gridWidth(metrics), alignment: .leading)
+        .frame(
+            width: gridWidth(presentation: presentation, metrics: metrics),
+            alignment: .leading
+        )
         .accessibilityElement(children: .contain)
         .accessibilityLabel("每日输入热力图")
     }
 
-    private func dayCell(_ date: Date, metrics: TypingHeatmapCellMetrics) -> some View {
-        let count = summariesByDate[calendar.startOfDay(for: date)]?.characterCount ?? 0
-        let level = heatLevel(for: count)
-        let dateText = date.formatted(.dateTime.year().month().day().weekday(.wide))
-        let helpText = "\(dateText)：\(formattedCount(count)) 个字符"
-
-        return RoundedRectangle(cornerRadius: 2, style: .continuous)
-            .fill(color(for: level))
+    private func dayCell(
+        _ cell: TypingYearHeatmapPresentation.DayCell,
+        metrics: TypingHeatmapCellMetrics,
+        exposesEmptyCellsToAssistiveTech: Bool
+    ) -> some View {
+        let content = RoundedRectangle(cornerRadius: 2, style: .continuous)
+            .fill(color(for: cell.level))
             .frame(width: metrics.cellSize, height: metrics.cellSize)
             .overlay {
                 RoundedRectangle(cornerRadius: 2, style: .continuous)
-                    .stroke(BattutaVisualStyle.instrumentSeparator, lineWidth: 0.5)
+                .stroke(BattutaVisualStyle.instrumentSeparator, lineWidth: 0.5)
             }
-            .help(helpText)
-            .accessibilityElement(children: .ignore)
-            .accessibilityLabel(dateText)
-            .accessibilityValue("\(formattedCount(count)) 个字符，活跃度第 \(level + 1) 级，共 5 级")
+
+        return Group {
+            if cell.hasInput {
+                content
+                    .help(cell.helpText)
+                    .accessibilityElement(children: .ignore)
+                    .accessibilityLabel(cell.dateText)
+                    .accessibilityValue(cell.accessibilityValue)
+            } else if exposesEmptyCellsToAssistiveTech {
+                content
+                    .accessibilityElement(children: .ignore)
+                    .accessibilityLabel(
+                        cell.date?.formatted(.dateTime.year().month().day().weekday(.wide))
+                            ?? "没有输入的日期"
+                    )
+                    .accessibilityValue("0 个字符")
+            } else {
+                content.accessibilityHidden(true)
+            }
+        }
     }
 
     private func legend(metrics: TypingHeatmapCellMetrics) -> some View {
@@ -295,9 +264,12 @@ struct TypingYearHeatmap: View {
         .accessibilityLabel("颜色图例，从少到多，共五级")
     }
 
-    private func gridWidth(_ metrics: TypingHeatmapCellMetrics) -> CGFloat {
-        CGFloat(weekCount) * metrics.cellSize
-            + CGFloat(max(0, weekCount - 1)) * metrics.spacing
+    private func gridWidth(
+        presentation: TypingYearHeatmapPresentation,
+        metrics: TypingHeatmapCellMetrics
+    ) -> CGFloat {
+        CGFloat(presentation.weekCount) * metrics.cellSize
+            + CGFloat(max(0, presentation.weekCount - 1)) * metrics.spacing
     }
 
     private func scale(_ metrics: TypingHeatmapCellMetrics) -> CGFloat {
@@ -310,25 +282,6 @@ struct TypingYearHeatmap: View {
 
     private func labelGridSpacing(_ metrics: TypingHeatmapCellMetrics) -> CGFloat {
         TypingHeatmapCellMetrics.spacing
-    }
-
-    private func date(weekIndex: Int, weekdayIndex: Int) -> Date? {
-        calendar.date(
-            byAdding: .day,
-            value: weekIndex * 7 + weekdayIndex,
-            to: gridStartDate
-        )
-    }
-
-    private func mondayBasedWeekdayIndex(for date: Date) -> Int {
-        let foundationWeekday = calendar.component(.weekday, from: date)
-        return (foundationWeekday + 5) % 7
-    }
-
-    private func heatLevel(for count: Int64) -> Int {
-        guard count > 0, maximumCount > 0 else { return 0 }
-        let normalized = log1p(Double(count)) / log1p(Double(maximumCount))
-        return min(4, max(1, Int(ceil(normalized * 4))))
     }
 
     private func color(for level: Int) -> Color {
@@ -346,23 +299,172 @@ struct TypingYearHeatmap: View {
         }
     }
 
-    private var rangeDescription: String {
-        let start = startDate.formatted(.dateTime.year().month().day())
-        let end = endDate.formatted(.dateTime.year().month().day())
-        return "\(start) – \(end)"
+}
+
+/// Immutable render data keeps calendar traversal, indexing, and string formatting
+/// out of the per-cell SwiftUI body path.
+private struct TypingYearHeatmapPresentation: Equatable {
+    struct DayCell: Identifiable, Equatable {
+        let id: Int
+        let date: Date?
+        let isVisible: Bool
+        let hasInput: Bool
+        let level: Int
+        let dateText: String
+        let helpText: String
+        let accessibilityValue: String
     }
 
-    private func monthTitle(_ date: Date) -> String {
-        date.formatted(.dateTime.month(.abbreviated))
+    struct Week: Identifiable, Equatable {
+        let index: Int
+        let cells: [DayCell]
+
+        var id: Int { index }
     }
 
-    private func formattedCount(_ count: Int64) -> String {
-        count.formatted(.number.grouping(.automatic))
+    let rangeDescription: String
+    let weekCount: Int
+    let monthMarkers: [MonthMarker]
+    let weeks: [Week]
+
+    init(range: TypingDateRange, days: [TypingDaySummary], calendar: Calendar) {
+        let startDate = calendar.startOfDay(for: range.startDate)
+        let endDate = calendar.startOfDay(for: range.endDate)
+        let gridStartDate = calendar.date(
+            byAdding: .day,
+            value: -Self.mondayBasedWeekdayIndex(for: startDate, calendar: calendar),
+            to: startDate
+        ) ?? startDate
+        let remainingDays = 6 - Self.mondayBasedWeekdayIndex(for: endDate, calendar: calendar)
+        let gridEndDate = calendar.date(byAdding: .day, value: remainingDays, to: endDate) ?? endDate
+        let gridDayCount = calendar.dateComponents(
+            [.day],
+            from: gridStartDate,
+            to: gridEndDate
+        ).day ?? 0
+        let resolvedWeekCount = max(1, gridDayCount / 7 + 1)
+        let countsByDate = days.reduce(into: [Date: Int64]()) { result, summary in
+            result[calendar.startOfDay(for: summary.date)] = summary.characterCount
+        }
+        let maximumCount = countsByDate.reduce(into: Int64(0)) { maximum, entry in
+            guard entry.key >= startDate, entry.key <= endDate else { return }
+            maximum = max(maximum, entry.value)
+        }
+
+        rangeDescription = "\(startDate.formatted(.dateTime.year().month().day())) – \(endDate.formatted(.dateTime.year().month().day()))"
+        weekCount = resolvedWeekCount
+        monthMarkers = Self.monthMarkers(
+            from: startDate,
+            through: endDate,
+            gridStartDate: gridStartDate,
+            calendar: calendar
+        )
+        weeks = (0..<resolvedWeekCount).map { weekIndex in
+            let cells = (0..<7).map { weekdayIndex in
+                let id = weekIndex * 7 + weekdayIndex
+                let date = calendar.date(
+                    byAdding: .day,
+                    value: id,
+                    to: gridStartDate
+                ) ?? startDate
+                guard date >= startDate, date <= endDate else {
+                    return DayCell(
+                        id: id,
+                        date: nil,
+                        isVisible: false,
+                        hasInput: false,
+                        level: 0,
+                        dateText: "",
+                        helpText: "",
+                        accessibilityValue: ""
+                    )
+                }
+
+                let count = countsByDate[date] ?? 0
+                let level = Self.heatLevel(for: count, maximumCount: maximumCount)
+                guard count > 0 else {
+                    return DayCell(
+                        id: id,
+                        date: date,
+                        isVisible: true,
+                        hasInput: false,
+                        level: level,
+                        dateText: "",
+                        helpText: "",
+                        accessibilityValue: ""
+                    )
+                }
+                let dateText = date.formatted(.dateTime.year().month().day().weekday(.wide))
+                let formattedCount = count.formatted(.number.grouping(.automatic))
+                return DayCell(
+                    id: id,
+                    date: date,
+                    isVisible: true,
+                    hasInput: count > 0,
+                    level: level,
+                    dateText: dateText,
+                    helpText: "\(dateText)：\(formattedCount) 个字符",
+                    accessibilityValue: "\(formattedCount) 个字符，活跃度第 \(level + 1) 级，共 5 级"
+                )
+            }
+            return Week(index: weekIndex, cells: cells)
+        }
+    }
+
+    private static func mondayBasedWeekdayIndex(for date: Date, calendar: Calendar) -> Int {
+        (calendar.component(.weekday, from: date) + 5) % 7
+    }
+
+    private static func heatLevel(for count: Int64, maximumCount: Int64) -> Int {
+        guard count > 0, maximumCount > 0 else { return 0 }
+        let normalized = log1p(Double(count)) / log1p(Double(maximumCount))
+        return min(4, max(1, Int(ceil(normalized * 4))))
+    }
+
+    private static func monthMarkers(
+        from startDate: Date,
+        through endDate: Date,
+        gridStartDate: Date,
+        calendar: Calendar
+    ) -> [MonthMarker] {
+        var markers: [MonthMarker] = []
+        var cursor = startDate
+        var previousMonth: Int?
+        var previousYear: Int?
+
+        while cursor <= endDate {
+            let month = calendar.component(.month, from: cursor)
+            let year = calendar.component(.year, from: cursor)
+            if month != previousMonth || year != previousYear {
+                let dayOffset = calendar.dateComponents(
+                    [.day],
+                    from: gridStartDate,
+                    to: cursor
+                ).day ?? 0
+                markers.append(
+                    MonthMarker(
+                        date: cursor,
+                        title: cursor.formatted(.dateTime.month(.abbreviated)),
+                        weekIndex: max(0, dayOffset / 7)
+                    )
+                )
+                previousMonth = month
+                previousYear = year
+            }
+
+            guard let next = calendar.date(byAdding: .day, value: 1, to: cursor), next > cursor else {
+                break
+            }
+            cursor = next
+        }
+
+        return markers
     }
 }
 
-private struct MonthMarker: Identifiable {
+private struct MonthMarker: Identifiable, Equatable {
     let date: Date
+    let title: String
     let weekIndex: Int
 
     var id: Date { date }


### PR DESCRIPTION
## Summary
- stop the history page from joining the periodic today-page refresh loop
- precompute annual/rhythm heatmap render data and avoid building both adaptive layouts
- cache resolved app icons and reduce inactive-cell hover/accessibility work

## Validation
- xcodebuild Release build (no code signing)
- typing stats, absolute volume, audio variant, DIY, and installer core harnesses (717 assertions)