### PR TITLE
feat: add local BCP Suit80 sound pack tooling

### DIFF
--- a/SimuBoardMac/AUDIO_SOURCES.md
+++ b/SimuBoardMac/AUDIO_SOURCES.md
@@ -1,8 +1,9 @@
 # Battuta audio sources
 
-This inventory records the provenance and redistribution status of audio that
-is bundled with Battuta. Derived files are trimmed and/or resampled to
-48 kHz mono PCM WAV unless noted otherwise.
+This inventory records the provenance, processing, and redistribution status of
+audio used by Battuta's shipped bundles or retained for local-only evaluation.
+Derived files are trimmed and/or resampled to 48 kHz mono PCM WAV unless noted
+otherwise.
 
 ## Bundled sources
 
@@ -16,6 +17,12 @@ is bundled with Battuta. Derived files are trimmed and/or resampled to
 | Kailh Low-profile Blue | [Fast Typing on Mechanical Keyboard](https://freesound.org/people/HeinzBBQ/sounds/502653/) by HeinzBBQ | Freesound ID `502653` | CC0 1.0 | Five 220 ms excerpts selected from the public HQ preview, downmixed and resampled; click and bottom-out remain in press while the later release event is separated and neighboring keystrokes are excluded |
 | Cherry MX Clear | [Mechanical keyboard clicking. Different keys (4)](https://freesound.org/people/humi74/sounds/412926/) by humi74 | Freesound ID `412926` | CC0 1.0 | Five 220 ms excerpts selected from the public HQ preview, downmixed and resampled, then separated at the audited energy valley before release; one excerpt without a usable release reuses the closest clean release variation from the same recording |
 | Pointer Classic, Silent, Crisp, Heavy, and Glass | [Kenney UI Audio](https://kenney.nl/assets/ui-audio) by Kenney Vleugels | Archive downloaded 2026-08-22; original files `mouseclick1.ogg` and `mouserelease1.ogg` | CC0 1.0 | The matched press/release recordings are downmixed and rendered as five generic simulated tonal treatments. Each phase is pitch-lowered with compensation for the associated tempo change, then receives profile-specific low-pass filtering, restrained midrange EQ and level adjustment; Crisp and Glass retain a gentle low cut for definition without the former high-frequency boost. Leading signal below −45 dBFS is removed while retaining up to 2 ms of pre-roll; all outputs have a 4 ms tail fade and are 48 kHz mono 16-bit PCM WAV. The profile names do not identify or claim to reproduce a particular mouse brand or switch. |
+
+## Local-only evaluation sources
+
+| Local evaluation profile | Local source file | Visible uploader | Recording | Processing | Redistribution status |
+| --- | --- | --- | --- | --- | --- |
+| BCP (Suit80) | `【打字声音】Suit80｜BCP轴｜GMK Ursa 大熊 - Original.mp4` | Bilibili `J_Eason001` | Suit80 / BCP / GMK Ursa | Rendered locally with `scripts/render-local-bcp-profile.sh` into `SimuBoardMac/build/BCP-rendered-assets`: stereo downmix, `-3 dB` headroom, `55 Hz` high-pass, conservative `afftdn` denoise with measured `25 ms` latency compensation, then 28 audited press/release cuts. Five base row pairs and five alternate small-key pairs use separated transients, a light `95 Hz` press high-pass, a light `108 Hz` release high-pass, and `1 ms` release fade-in. Three late secondary impacts are excluded to prevent cumulative desk resonance during rapid typing; dedicated Shift, Backspace, Enter, and Space pairs retain their prior cuts and processing. `scripts/install-local-bcp-sound-pack.sh` validates those WAVs and installs a local `.simuboardpack` into `~/Library/Application Support/SimuBoard/SoundPacks` | Not a licensed bundled source. The rendered WAV assets and installed local pack are for local machine evaluation only, must stay untracked, and must be removed or excluded from any public build, DMG, appcast, or release until the rightsholder grants redistribution permission |
 
 The imported files can be reproduced with:
 
@@ -64,6 +71,13 @@ generated copies, so stale files cannot survive a re-import.
 The copyright notices and license terms required for redistribution are in
 `SimuBoardMac/Resources/THIRD_PARTY_NOTICES.txt` and the repository-level
 `THIRD_PARTY_NOTICES.md`.
+
+The local BCP evaluation assets are explicitly excluded from public shipping.
+They are not licensed bundled sources, and they must not be copied into the
+app bundle for release builds. The generated `build/BCP-rendered-assets`
+directory and the installed local `.simuboardpack` must stay untracked and must
+be removed or excluded from any public build, DMG, appcast, release, or public
+repository until the rightsholder grants redistribution permission.
 
 ## Evaluated but not bundled
 

--- a/SimuBoardMac/Tests/DIYCoreHarness.swift
+++ b/SimuBoardMac/Tests/DIYCoreHarness.swift
@@ -109,7 +109,7 @@ private struct PCM16MonoWave {
               format.channels == 1,
               format.bits == 16,
               sampleBytes.count.isMultiple(of: 2) else {
-            throw HarnessFailure.assertion("pointer WAV must be mono 16-bit PCM: \(url.path)")
+            throw HarnessFailure.assertion("WAV must be mono 16-bit PCM: \(url.path)")
         }
 
         var decoded = [Int16]()
@@ -122,7 +122,7 @@ private struct PCM16MonoWave {
             sampleOffset += 2
         }
         guard !decoded.isEmpty else {
-            throw HarnessFailure.assertion("pointer WAV has no samples: \(url.path)")
+            throw HarnessFailure.assertion("WAV has no samples: \(url.path)")
         }
 
         sampleRate = Int(format.sampleRate)
@@ -281,8 +281,17 @@ private actor FetchRecorder {
     var callCount: Int { etags.count }
 }
 
+private struct PackSnapshot: Equatable {
+    let manifestData: Data
+    let assetHashes: [String: String]
+}
+
 @main
 private struct DIYCoreHarness {
+    private static let bcpFixtureTitle = "【打字声音】Suit80｜BCP轴｜GMK Ursa 大熊 - Original.mp4"
+    private static let bcpPackUUID = UUID(uuidString: "15d04652-5265-4ea7-a376-8a7e11ff6813")!
+    private static let bcpSelectionID = "custom:15d04652-5265-4ea7-a376-8a7e11ff6813"
+
     static func main() async {
         var results = HarnessResults()
         do {
@@ -290,6 +299,7 @@ private struct DIYCoreHarness {
             try testKeyboardVisualLayout(&results)
             try testPointerEventMapping(&results)
             try testPointerSettingsAndResources(&results)
+            try await testLocalBCPSoundPackInstaller(&results)
             try testLaunchAtLoginInstallPaths(&results)
             try testValidatorAndResolver(&results)
             try await testAudioLibraryAndArchive(&results)
@@ -691,6 +701,534 @@ private struct DIYCoreHarness {
         try results.check(
             orderedCentroids.sorted()[orderedCentroids.count / 2] < 6_000,
             "the median pointer profile must remain comfortably below a 6 kHz spectral centroid"
+        )
+    }
+
+    private static func testLocalBCPSoundPackInstaller(
+        _ results: inout HarnessResults
+    ) async throws {
+        let fileManager = FileManager.default
+        let projectRoot = URL(fileURLWithPath: fileManager.currentDirectoryPath)
+        let scriptURL = projectRoot.appendingPathComponent(
+            "SimuBoardMac/scripts/install-local-bcp-sound-pack.sh"
+        )
+        try results.check(
+            fileManager.isExecutableFile(atPath: scriptURL.path),
+            "local BCP installer script must exist and be executable"
+        )
+
+        let root = fileManager.temporaryDirectory.appendingPathComponent(
+            "SimuBoard-LocalBCPInstaller-\(UUID().uuidString)",
+            isDirectory: true
+        )
+        let assetRoot = root.appendingPathComponent("assets", isDirectory: true)
+        try fileManager.createDirectory(at: assetRoot, withIntermediateDirectories: true)
+        defer { try? fileManager.removeItem(at: root) }
+
+        try makeBCPInstallerFixtureAssets(at: assetRoot, variantOffset: 0)
+
+        let homeRoot = root.appendingPathComponent("home", isDirectory: true)
+        try fileManager.createDirectory(
+            at: homeRoot.appendingPathComponent("Library/Preferences", isDirectory: true),
+            withIntermediateDirectories: true
+        )
+        let defaultLibraryRoot = defaultBCPLibraryRoot(forHome: homeRoot)
+        let migrationDomain = "com.simuboard.bcp-installer.migration.\(UUID().uuidString)"
+        try writeSelectedProfile(
+            "bcp",
+            domain: migrationDomain,
+            homeDirectory: homeRoot
+        )
+        let firstRun = try runProcess(
+            executableURL: scriptURL,
+            arguments: [assetRoot.path],
+            currentDirectoryURL: projectRoot.appendingPathComponent("SimuBoardMac", isDirectory: true),
+            environmentOverrides: [
+                "HOME": homeRoot.path,
+                "SIMUBOARD_DEFAULTS_DOMAIN": migrationDomain,
+                "SIMUBOARD_INSTALLER_NOW": "2026-08-24T08:00:00Z",
+            ]
+        )
+        try results.check(
+            firstRun.terminationStatus == 0,
+            "local BCP installer must succeed: \(firstRun.stderr)"
+        )
+        let migratedSelectedProfile = try readSelectedProfile(
+            domain: migrationDomain,
+            homeDirectory: homeRoot
+        )
+        try results.check(
+            migratedSelectedProfile == bcpSelectionID,
+            "installing into the default local library root must migrate the legacy bundled BCP selection"
+        )
+
+        let explicitDefaultDomain = "com.simuboard.bcp-installer.explicit-default.\(UUID().uuidString)"
+        let explicitDefaultHomeRoot = root.appendingPathComponent(
+            "explicit-default-home",
+            isDirectory: true
+        )
+        try fileManager.createDirectory(
+            at: explicitDefaultHomeRoot.appendingPathComponent(
+                "Library/Preferences",
+                isDirectory: true
+            ),
+            withIntermediateDirectories: true
+        )
+        let explicitDefaultLibraryRoot = defaultBCPLibraryRoot(forHome: explicitDefaultHomeRoot)
+        try writeSelectedProfile(
+            "bcp",
+            domain: explicitDefaultDomain,
+            homeDirectory: explicitDefaultHomeRoot
+        )
+        let explicitDefaultRun = try runProcess(
+            executableURL: scriptURL,
+            arguments: [assetRoot.path, explicitDefaultLibraryRoot.path],
+            currentDirectoryURL: projectRoot.appendingPathComponent("SimuBoardMac", isDirectory: true),
+            environmentOverrides: [
+                "HOME": explicitDefaultHomeRoot.path,
+                "SIMUBOARD_DEFAULTS_DOMAIN": explicitDefaultDomain,
+                "SIMUBOARD_INSTALLER_NOW": "2026-08-24T08:00:00Z",
+            ]
+        )
+        try results.check(
+            explicitDefaultRun.terminationStatus == 0,
+            "explicit default library-root install must still succeed: \(explicitDefaultRun.stderr)"
+        )
+        let explicitDefaultSelectedProfile = try readSelectedProfile(
+            domain: explicitDefaultDomain,
+            homeDirectory: explicitDefaultHomeRoot
+        )
+        try results.check(
+            explicitDefaultSelectedProfile == bcpSelectionID,
+            "explicit default library-root installs must still migrate the legacy bundled BCP selection"
+        )
+
+        let installedPackURLs = try fileManager.contentsOfDirectory(
+            at: defaultLibraryRoot,
+            includingPropertiesForKeys: [.isDirectoryKey],
+            options: [.skipsHiddenFiles]
+        ).filter { $0.pathExtension.lowercased() == "simuboardpack" }
+        try results.check(
+            installedPackURLs.count == 1,
+            "installer must publish exactly one BCP custom pack"
+        )
+        guard let installedPackURL = installedPackURLs.first else { return }
+
+        let manifest = try SoundPackPackageValidator.validatePackage(at: installedPackURL)
+        try results.check(
+            installedPackURL.lastPathComponent == "\(manifest.id.uuidString.lowercased()).simuboardpack",
+            "installer directory name must match manifest UUID"
+        )
+        try results.check(manifest.name == "BCP (Suit80)", "installed pack name must match the picker label")
+        try results.check(manifest.family == "线性", "installed pack family must remain linear")
+        try results.check(manifest.tone == "厚实、木感", "installed pack tone must remain thick and woody")
+        try results.check(
+            manifest.layoutID == KeyboardLayoutCatalog.defaultLayoutID,
+            "installed pack must target the persisted ANSI TKL layout"
+        )
+        try results.check(
+            manifest.baseProfileID == SwitchProfile.holyPanda.rawValue,
+            "installed pack must fall back to Holy Panda"
+        )
+        try results.check(manifest.press.generic == nil, "press mapping must not use a generic fallback asset")
+        try results.check(manifest.release.generic == nil, "release mapping must not use a generic fallback asset")
+        try results.check(
+            manifest.press.rows.keys.sorted() == KeyboardRowID.allCases.map(\.rawValue).sorted(),
+            "press mapping must cover every keyboard row"
+        )
+        try results.check(
+            manifest.release.rows.keys.sorted() == KeyboardRowID.allCases.map(\.rawValue).sorted(),
+            "release mapping must cover every keyboard row"
+        )
+        try results.check(
+            manifest.press.specials.keys.sorted() == KeyboardSpecialKeyID.allCases.map(\.rawValue).sorted(),
+            "press mapping must cover every supported special key"
+        )
+        try results.check(
+            manifest.release.specials.keys.sorted() == KeyboardSpecialKeyID.allCases.map(\.rawValue).sorted(),
+            "release mapping must cover every supported special key"
+        )
+        let expectedOverrideKeys = Set([
+            "digit2", "digit4", "digit6", "digit8", "digit0", "equal",
+            "w", "r", "y", "i", "p", "rightBracket",
+            "s", "f", "h", "k", "semicolon",
+            "x", "v", "n", "comma", "slash",
+            "f2", "f4", "f6", "f8", "f10", "f12", "upArrow", "rightArrow",
+            "leftShift", "rightShift",
+        ])
+        try results.check(
+            Set(manifest.press.keyOverrides.keys) == expectedOverrideKeys
+                && Set(manifest.release.keyOverrides.keys) == expectedOverrideKeys,
+            "installer must map all alternate row samples and both Shift keys"
+        )
+        try results.check(
+            manifest.press.override(for: KeyboardKeyID("leftShift"))
+                == manifest.press.override(for: KeyboardKeyID("rightShift"))
+                && manifest.release.override(for: KeyboardKeyID("leftShift"))
+                    == manifest.release.override(for: KeyboardKeyID("rightShift")),
+            "left and right Shift must share the dedicated Shift sample in each phase"
+        )
+        try results.check(manifest.assets.count == 28, "installer must preserve all 28 rendered assets")
+        try results.check(manifest.attributions.count == 1, "installer must emit one attribution entry")
+        if let attribution = manifest.attributions.first {
+            try results.check(
+                attribution.title == bcpFixtureTitle,
+                "attribution title must preserve the recording filename"
+            )
+            try results.check(
+                attribution.author == "J_Eason001",
+                "attribution author must preserve the visible uploader"
+            )
+            try results.check(attribution.sourceURL == nil, "attribution must not invent a source URL")
+            try results.check(attribution.licenseName == nil, "attribution must not invent a license")
+            try results.check(
+                attribution.notice == "Permission unverified. Local evaluation only. Do not redistribute.",
+                "attribution notice must preserve the local-only shipping boundary"
+            )
+        }
+
+        let firstPressR0Asset = manifest.press.asset(for: .r0)
+        let firstReleaseSpaceAsset = manifest.release.asset(for: .space)
+        try results.check(firstPressR0Asset != nil, "press R0 assignment must exist")
+        try results.check(firstReleaseSpaceAsset != nil, "release Space assignment must exist")
+
+        let library = SoundPackLibrary(rootURL: defaultLibraryRoot, builtInDescriptors: [])
+        let descriptors = try await library.descriptors()
+        try results.check(descriptors.count == 1, "installed pack should appear in the custom library")
+        try results.check(
+            descriptors.first?.customPackID == manifest.id,
+            "installed pack descriptor must point to the installed UUID"
+        )
+
+        let explicitDomain = "com.simuboard.bcp-installer.explicit.\(UUID().uuidString)"
+        let explicitHomeRoot = root.appendingPathComponent("explicit-home", isDirectory: true)
+        try fileManager.createDirectory(
+            at: explicitHomeRoot.appendingPathComponent("Library/Preferences", isDirectory: true),
+            withIntermediateDirectories: true
+        )
+        let explicitLibraryRoot = root.appendingPathComponent("explicit-library", isDirectory: true)
+        try writeSelectedProfile(
+            "bcp",
+            domain: explicitDomain,
+            homeDirectory: explicitHomeRoot
+        )
+        let explicitRun = try runProcess(
+            executableURL: scriptURL,
+            arguments: [assetRoot.path, explicitLibraryRoot.path],
+            currentDirectoryURL: projectRoot.appendingPathComponent("SimuBoardMac", isDirectory: true),
+            environmentOverrides: [
+                "HOME": explicitHomeRoot.path,
+                "SIMUBOARD_DEFAULTS_DOMAIN": explicitDomain,
+                "SIMUBOARD_INSTALLER_NOW": "2026-08-24T08:00:00Z",
+            ]
+        )
+        try results.check(
+            explicitRun.terminationStatus == 0,
+            "explicit library-root install must still succeed: \(explicitRun.stderr)"
+        )
+        let explicitSelectedProfile = try readSelectedProfile(
+            domain: explicitDomain,
+            homeDirectory: explicitHomeRoot
+        )
+        try results.check(
+            explicitSelectedProfile == "bcp",
+            "explicit library-root installs must not rewrite the user's selected profile"
+        )
+
+        let timestampLibraryRoot = root.appendingPathComponent("timestamp-library", isDirectory: true)
+        let timestampInstall1 = try runProcess(
+            executableURL: scriptURL,
+            arguments: [assetRoot.path, timestampLibraryRoot.path],
+            currentDirectoryURL: projectRoot.appendingPathComponent("SimuBoardMac", isDirectory: true),
+            environmentOverrides: [
+                "SIMUBOARD_INSTALLER_NOW": "2026-08-24T08:00:00Z",
+            ]
+        )
+        try results.check(
+            timestampInstall1.terminationStatus == 0,
+            "first timestamp fixture install must succeed: \(timestampInstall1.stderr)"
+        )
+        let timestampPackURL = bcpPackURL(in: timestampLibraryRoot)
+        let timestampManifest1 = try SoundPackPackageValidator.validatePackage(at: timestampPackURL)
+        let timestampInstall2 = try runProcess(
+            executableURL: scriptURL,
+            arguments: [assetRoot.path, timestampLibraryRoot.path],
+            currentDirectoryURL: projectRoot.appendingPathComponent("SimuBoardMac", isDirectory: true),
+            environmentOverrides: [
+                "SIMUBOARD_INSTALLER_NOW": "2026-08-24T09:00:00Z",
+            ]
+        )
+        try results.check(
+            timestampInstall2.terminationStatus == 0,
+            "same-input reinstall must succeed: \(timestampInstall2.stderr)"
+        )
+        let timestampManifest2 = try SoundPackPackageValidator.validatePackage(at: timestampPackURL)
+        try results.check(
+            timestampManifest2.createdAt == timestampManifest1.createdAt,
+            "same-input reinstall must preserve createdAt"
+        )
+        try results.check(
+            timestampManifest2.modifiedAt == timestampManifest1.modifiedAt,
+            "same-input reinstall must preserve modifiedAt for byte-stable manifests"
+        )
+
+        try makeBCPInstallerFixtureAssets(at: assetRoot, variantOffset: 1)
+        let timestampInstall3 = try runProcess(
+            executableURL: scriptURL,
+            arguments: [assetRoot.path, timestampLibraryRoot.path],
+            currentDirectoryURL: projectRoot.appendingPathComponent("SimuBoardMac", isDirectory: true),
+            environmentOverrides: [
+                "SIMUBOARD_INSTALLER_NOW": "2026-08-24T10:00:00Z",
+            ]
+        )
+        try results.check(
+            timestampInstall3.terminationStatus == 0,
+            "changed-input reinstall must succeed: \(timestampInstall3.stderr)"
+        )
+        let timestampManifest3 = try SoundPackPackageValidator.validatePackage(at: timestampPackURL)
+        try results.check(
+            timestampManifest3.createdAt == timestampManifest1.createdAt,
+            "changed-input reinstall must preserve the original createdAt"
+        )
+        try results.check(
+            timestampManifest3.modifiedAt == iso8601Date("2026-08-24T10:00:00Z"),
+            "changed-input reinstall must update modifiedAt to the new install time"
+        )
+
+        try makeBCPInstallerFixtureAssets(at: assetRoot, variantOffset: 0)
+
+        let corruptTimestampLibraryRoot = root.appendingPathComponent(
+            "corrupt-timestamp-library",
+            isDirectory: true
+        )
+        let corruptTimestampPackURL = try installBCPFixturePack(
+            scriptURL: scriptURL,
+            assetRoot: assetRoot,
+            libraryRoot: corruptTimestampLibraryRoot,
+            projectRoot: projectRoot,
+            installTime: "2026-08-24T10:30:00Z"
+        )
+        try rewriteManifestJSONObject(at: corruptTimestampPackURL) { manifest in
+            manifest["createdAt"] = "2026-08-24T10:30:00+08:00"
+        }
+        let corruptTimestampSnapshot = try snapshot(packAt: corruptTimestampPackURL)
+        let corruptTimestampRun = try runProcess(
+            executableURL: scriptURL,
+            arguments: [assetRoot.path, corruptTimestampLibraryRoot.path],
+            currentDirectoryURL: projectRoot.appendingPathComponent("SimuBoardMac", isDirectory: true),
+            environmentOverrides: [
+                "SIMUBOARD_INSTALLER_NOW": "2026-08-24T10:31:00Z",
+            ]
+        )
+        try results.check(
+            corruptTimestampRun.terminationStatus != 0,
+            "installer must reject an existing fixed BCP pack with non-UTC timestamps"
+        )
+        let corruptTimestampSnapshotAfterRun = try snapshot(packAt: corruptTimestampPackURL)
+        try results.check(
+            corruptTimestampSnapshotAfterRun == corruptTimestampSnapshot,
+            "rejecting corrupt timestamps must leave the old fixed BCP pack untouched"
+        )
+
+        let corruptAssetLibraryRoot = root.appendingPathComponent(
+            "corrupt-asset-library",
+            isDirectory: true
+        )
+        let corruptAssetPackURL = try installBCPFixturePack(
+            scriptURL: scriptURL,
+            assetRoot: assetRoot,
+            libraryRoot: corruptAssetLibraryRoot,
+            projectRoot: projectRoot,
+            installTime: "2026-08-24T10:40:00Z"
+        )
+        try corruptOneBCPAsset(at: corruptAssetPackURL)
+        let corruptAssetSnapshot = try snapshot(packAt: corruptAssetPackURL)
+        let corruptAssetRun = try runProcess(
+            executableURL: scriptURL,
+            arguments: [assetRoot.path, corruptAssetLibraryRoot.path],
+            currentDirectoryURL: projectRoot.appendingPathComponent("SimuBoardMac", isDirectory: true),
+            environmentOverrides: [
+                "SIMUBOARD_INSTALLER_NOW": "2026-08-24T10:41:00Z",
+            ]
+        )
+        try results.check(
+            corruptAssetRun.terminationStatus != 0,
+            "installer must reject an existing fixed BCP pack whose asset bytes no longer match the manifest"
+        )
+        let corruptAssetSnapshotAfterRun = try snapshot(packAt: corruptAssetPackURL)
+        try results.check(
+            corruptAssetSnapshotAfterRun == corruptAssetSnapshot,
+            "rejecting corrupt asset bytes must leave the old fixed BCP pack untouched"
+        )
+
+        let malformedMappingLibraryRoot = root.appendingPathComponent(
+            "malformed-mapping-library",
+            isDirectory: true
+        )
+        let malformedMappingPackURL = try installBCPFixturePack(
+            scriptURL: scriptURL,
+            assetRoot: assetRoot,
+            libraryRoot: malformedMappingLibraryRoot,
+            projectRoot: projectRoot,
+            installTime: "2026-08-24T10:50:00Z"
+        )
+        try rewriteManifestJSONObject(at: malformedMappingPackURL) { manifest in
+            guard var press = manifest["press"] as? [String: Any] else {
+                throw HarnessFailure.assertion("fixture press assignments must exist")
+            }
+            press["generic"] = String(repeating: "a", count: 64)
+            manifest["press"] = press
+        }
+        let malformedMappingSnapshot = try snapshot(packAt: malformedMappingPackURL)
+        let malformedMappingRun = try runProcess(
+            executableURL: scriptURL,
+            arguments: [assetRoot.path, malformedMappingLibraryRoot.path],
+            currentDirectoryURL: projectRoot.appendingPathComponent("SimuBoardMac", isDirectory: true),
+            environmentOverrides: [
+                "SIMUBOARD_INSTALLER_NOW": "2026-08-24T10:51:00Z",
+            ]
+        )
+        try results.check(
+            malformedMappingRun.terminationStatus != 0,
+            "installer must reject an existing fixed BCP pack with malformed fixed-row assignments"
+        )
+        let malformedMappingSnapshotAfterRun = try snapshot(packAt: malformedMappingPackURL)
+        try results.check(
+            malformedMappingSnapshotAfterRun == malformedMappingSnapshot,
+            "rejecting malformed mappings must leave the old fixed BCP pack untouched"
+        )
+
+        try makeBCPInstallerFixtureAssets(at: assetRoot, variantOffset: 0)
+        let sentinelID = UUID()
+        let rollbackLibraryRoot = root.appendingPathComponent("rollback-library", isDirectory: true)
+        let rollbackInitialAssetRoot = root.appendingPathComponent(
+            "rollback-initial-assets",
+            isDirectory: true
+        )
+        try makeBCPInstallerFixtureAssets(at: rollbackInitialAssetRoot, variantOffset: 9)
+        let rollbackLegacyPackURL = try installBCPFixturePack(
+            scriptURL: scriptURL,
+            assetRoot: rollbackInitialAssetRoot,
+            libraryRoot: rollbackLibraryRoot,
+            projectRoot: projectRoot,
+            installTime: "2026-08-20T08:00:00Z"
+        )
+        try setManifestTimestamps(
+            at: rollbackLegacyPackURL,
+            createdAt: iso8601Date("2026-08-20T08:00:00Z"),
+            modifiedAt: iso8601Date("2026-08-21T09:30:00Z")
+        )
+        let rollbackLegacySnapshot = try snapshot(packAt: rollbackLegacyPackURL)
+        let rollbackLibrary = SoundPackLibrary(rootURL: rollbackLibraryRoot, builtInDescriptors: [])
+        _ = try await rollbackLibrary.save(
+            manifest: SoundPackManifest(
+                id: sentinelID,
+                name: "Sentinel",
+                baseProfileID: SwitchProfile.holyPanda.rawValue
+            )
+        )
+        let sentinelPackURL = await rollbackLibrary.packURL(id: sentinelID)
+        let sentinelSnapshot = try snapshot(packAt: sentinelPackURL)
+        try results.check(
+            fileManager.fileExists(atPath: sentinelPackURL.path),
+            "fixture sentinel pack must exist before reinstall"
+        )
+
+        let failAfterBackup = try runProcess(
+            executableURL: scriptURL,
+            arguments: [assetRoot.path, rollbackLibraryRoot.path],
+            currentDirectoryURL: projectRoot.appendingPathComponent("SimuBoardMac", isDirectory: true),
+            environmentOverrides: [
+                "SIMUBOARD_INSTALLER_FAIL_AT": "after-backup",
+                "SIMUBOARD_INSTALLER_NOW": "2026-08-24T11:00:00Z",
+            ]
+        )
+        try results.check(
+            failAfterBackup.terminationStatus != 0,
+            "after-backup failure injection must fail the installer"
+        )
+        let rollbackSnapshotAfterBackup = try snapshot(packAt: rollbackLegacyPackURL)
+        try results.check(
+            rollbackSnapshotAfterBackup == rollbackLegacySnapshot,
+            "after-backup rollback must restore the original BCP pack exactly"
+        )
+        let sentinelSnapshotAfterBackup = try snapshot(packAt: sentinelPackURL)
+        try results.check(
+            sentinelSnapshotAfterBackup == sentinelSnapshot,
+            "after-backup rollback must leave unrelated packs untouched"
+        )
+
+        let failAfterInstallBeforeCommit = try runProcess(
+            executableURL: scriptURL,
+            arguments: [assetRoot.path, rollbackLibraryRoot.path],
+            currentDirectoryURL: projectRoot.appendingPathComponent("SimuBoardMac", isDirectory: true),
+            environmentOverrides: [
+                "SIMUBOARD_INSTALLER_FAIL_AT": "after-install-before-commit",
+                "SIMUBOARD_INSTALLER_NOW": "2026-08-24T12:00:00Z",
+            ]
+        )
+        try results.check(
+            failAfterInstallBeforeCommit.terminationStatus != 0,
+            "after-install-before-commit failure injection must fail the installer"
+        )
+        let rollbackSnapshotAfterInstallFailure = try snapshot(packAt: rollbackLegacyPackURL)
+        try results.check(
+            rollbackSnapshotAfterInstallFailure == rollbackLegacySnapshot,
+            "after-install-before-commit rollback must restore the original BCP pack exactly"
+        )
+        let sentinelSnapshotAfterInstallFailure = try snapshot(packAt: sentinelPackURL)
+        try results.check(
+            sentinelSnapshotAfterInstallFailure == sentinelSnapshot,
+            "after-install-before-commit rollback must leave unrelated packs untouched"
+        )
+
+        let noExistingLibraryRoot = root.appendingPathComponent("no-existing-library", isDirectory: true)
+        let failWithoutExisting = try runProcess(
+            executableURL: scriptURL,
+            arguments: [assetRoot.path, noExistingLibraryRoot.path],
+            currentDirectoryURL: projectRoot.appendingPathComponent("SimuBoardMac", isDirectory: true),
+            environmentOverrides: [
+                "SIMUBOARD_INSTALLER_FAIL_AT": "after-install-before-commit",
+                "SIMUBOARD_INSTALLER_NOW": "2026-08-24T12:30:00Z",
+            ]
+        )
+        try results.check(
+            failWithoutExisting.terminationStatus != 0,
+            "after-install-before-commit must fail even when there was no prior pack"
+        )
+        try results.check(
+            !fileManager.fileExists(atPath: bcpPackURL(in: noExistingLibraryRoot).path),
+            "failed first-time install must not leave a partial BCP pack behind"
+        )
+
+        let invalidLibraryRoot = root.appendingPathComponent("invalid-existing-library", isDirectory: true)
+        let invalidPackURL = bcpPackURL(in: invalidLibraryRoot)
+        try fileManager.createDirectory(
+            at: invalidPackURL.appendingPathComponent("assets", isDirectory: true),
+            withIntermediateDirectories: true
+        )
+        try Data("not-json".utf8).write(
+            to: invalidPackURL.appendingPathComponent("manifest.json"),
+            options: .atomic
+        )
+        let invalidRun = try runProcess(
+            executableURL: scriptURL,
+            arguments: [assetRoot.path, invalidLibraryRoot.path],
+            currentDirectoryURL: projectRoot.appendingPathComponent("SimuBoardMac", isDirectory: true),
+            environmentOverrides: [
+                "SIMUBOARD_INSTALLER_NOW": "2026-08-24T13:00:00Z",
+            ]
+        )
+        try results.check(
+            invalidRun.terminationStatus != 0,
+            "installer must reject an invalid existing fixed-pack manifest instead of overwriting it"
+        )
+        try results.check(
+            fileManager.fileExists(atPath: invalidPackURL.path)
+                && !fileManager.fileExists(
+                    atPath: invalidPackURL.appendingPathComponent("assets").appendingPathComponent("03598ddc778f4bcc03a28f59ada841dd663750846bc6449ff0fb3d9169fce057.wav").path
+                ),
+            "rejecting an invalid existing fixed-pack manifest must leave the original directory untouched"
         )
     }
 
@@ -1514,6 +2052,235 @@ private struct DIYCoreHarness {
         SoundPackAssetID(String(repeating: String(character), count: 64))
     }
 
+    private static func runProcess(
+        executableURL: URL,
+        arguments: [String],
+        currentDirectoryURL: URL,
+        environmentOverrides: [String: String] = [:]
+    ) throws -> (terminationStatus: Int32, stdout: String, stderr: String) {
+        let process = Process()
+        process.executableURL = executableURL
+        process.arguments = arguments
+        process.currentDirectoryURL = currentDirectoryURL
+        if !environmentOverrides.isEmpty {
+            process.environment = ProcessInfo.processInfo.environment.merging(environmentOverrides) { _, new in new }
+        }
+
+        let stdoutPipe = Pipe()
+        let stderrPipe = Pipe()
+        process.standardOutput = stdoutPipe
+        process.standardError = stderrPipe
+
+        try process.run()
+        process.waitUntilExit()
+
+        let stdoutData = stdoutPipe.fileHandleForReading.readDataToEndOfFile()
+        let stderrData = stderrPipe.fileHandleForReading.readDataToEndOfFile()
+        return (
+            process.terminationStatus,
+            String(decoding: stdoutData, as: UTF8.self),
+            String(decoding: stderrData, as: UTF8.self)
+        )
+    }
+
+    private static func defaultBCPLibraryRoot(forHome homeDirectory: URL) -> URL {
+        homeDirectory
+            .appendingPathComponent("Library/Application Support/SimuBoard", isDirectory: true)
+            .appendingPathComponent("SoundPacks", isDirectory: true)
+    }
+
+    private static func bcpPackURL(in libraryRoot: URL) -> URL {
+        libraryRoot.appendingPathComponent(
+            "\(bcpPackUUID.uuidString.lowercased()).simuboardpack",
+            isDirectory: true
+        )
+    }
+
+    private static func writeSelectedProfile(
+        _ value: String,
+        domain: String,
+        homeDirectory: URL
+    ) throws {
+        let result = try runProcess(
+            executableURL: URL(fileURLWithPath: "/usr/bin/defaults"),
+            arguments: ["write", domain, "selectedProfile", "-string", value],
+            currentDirectoryURL: homeDirectory,
+            environmentOverrides: ["HOME": homeDirectory.path]
+        )
+        guard result.terminationStatus == 0 else {
+            throw HarnessFailure.assertion("defaults write failed: \(result.stderr)")
+        }
+    }
+
+    private static func readSelectedProfile(
+        domain: String,
+        homeDirectory: URL
+    ) throws -> String? {
+        let result = try runProcess(
+            executableURL: URL(fileURLWithPath: "/usr/bin/defaults"),
+            arguments: ["read", domain, "selectedProfile"],
+            currentDirectoryURL: homeDirectory,
+            environmentOverrides: ["HOME": homeDirectory.path]
+        )
+        guard result.terminationStatus == 0 else { return nil }
+        return result.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private static func iso8601Date(_ value: String) -> Date {
+        let formatter = ISO8601DateFormatter()
+        guard let date = formatter.date(from: value) else {
+            preconditionFailure("invalid ISO-8601 fixture: \(value)")
+        }
+        return date
+    }
+
+    private static func installBCPFixturePack(
+        scriptURL: URL,
+        assetRoot: URL,
+        libraryRoot: URL,
+        projectRoot: URL,
+        installTime: String
+    ) throws -> URL {
+        let result = try runProcess(
+            executableURL: scriptURL,
+            arguments: [assetRoot.path, libraryRoot.path],
+            currentDirectoryURL: projectRoot.appendingPathComponent("SimuBoardMac", isDirectory: true),
+            environmentOverrides: [
+                "SIMUBOARD_INSTALLER_NOW": installTime,
+            ]
+        )
+        guard result.terminationStatus == 0 else {
+            throw HarnessFailure.assertion(
+                "fixture BCP install failed at \(installTime): \(result.stderr)"
+            )
+        }
+        return bcpPackURL(in: libraryRoot)
+    }
+
+    private static func setManifestTimestamps(
+        at packURL: URL,
+        createdAt: Date,
+        modifiedAt: Date
+    ) throws {
+        var manifest = try SoundPackPackageValidator.validatePackage(at: packURL)
+        manifest.createdAt = createdAt
+        manifest.modifiedAt = modifiedAt
+        try SoundPackCoding.encode(manifest).write(
+            to: packURL.appendingPathComponent("manifest.json"),
+            options: .atomic
+        )
+    }
+
+    private static func rewriteManifestJSONObject(
+        at packURL: URL,
+        mutate: (inout [String: Any]) throws -> Void
+    ) throws {
+        let manifestURL = packURL.appendingPathComponent("manifest.json")
+        let data = try Data(contentsOf: manifestURL, options: [.mappedIfSafe])
+        guard var manifest = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            throw HarnessFailure.assertion("manifest fixture must decode as a JSON object")
+        }
+        try mutate(&manifest)
+        let rewritten = try JSONSerialization.data(
+            withJSONObject: manifest,
+            options: [.prettyPrinted, .sortedKeys]
+        )
+        try rewritten.write(to: manifestURL, options: .atomic)
+    }
+
+    private static func installFixturePack(
+        in libraryRoot: URL,
+        packID: UUID,
+        name: String,
+        assetVariant: Int,
+        createdAt: Date,
+        modifiedAt: Date,
+        workingRoot: URL
+    ) async throws -> URL {
+        let assetURL = workingRoot.appendingPathComponent(
+            "fixture-\(packID.uuidString)-\(assetVariant).wav"
+        )
+        try makePCM16MonoFixture(
+            at: assetURL,
+            sampleRate: 48_000,
+            duration: 0.072,
+            frequency: 160 + Double(assetVariant * 17),
+            peakAmplitude: 0.28
+        )
+        let info = try AudioImportService.validateNormalizedAudio(at: assetURL)
+        let sha256 = try SoundPackFileUtilities.sha256(of: assetURL)
+        let assetID = SoundPackAssetID(sha256)
+        let manifest = SoundPackManifest(
+            id: packID,
+            name: name,
+            family: "Legacy",
+            tone: "Fixture",
+            baseProfileID: SwitchProfile.holyPanda.rawValue,
+            press: SoundPackPhaseAssignments(generic: assetID),
+            release: SoundPackPhaseAssignments(generic: assetID),
+            assets: [
+                assetID.rawValue: SoundPackAudioAsset(
+                    id: assetID,
+                    relativePath: "assets/\(assetID.rawValue).wav",
+                    sha256: assetID.rawValue,
+                    originalFilename: "fixture.wav",
+                    durationSeconds: info.durationSeconds,
+                    sampleRate: info.sampleRate,
+                    channelCount: info.channelCount,
+                    byteCount: info.byteCount
+                )
+            ]
+        )
+        let library = SoundPackLibrary(rootURL: libraryRoot, builtInDescriptors: [])
+        _ = try await library.save(
+            manifest: manifest,
+            assetFiles: [assetID: assetURL]
+        )
+        let packURL = await library.packURL(id: packID)
+        var installedManifest = try SoundPackPackageValidator.validatePackage(at: packURL)
+        installedManifest.createdAt = createdAt
+        installedManifest.modifiedAt = modifiedAt
+        let manifestData = try SoundPackCoding.encode(installedManifest)
+        try manifestData.write(
+            to: packURL.appendingPathComponent("manifest.json"),
+            options: .atomic
+        )
+        return packURL
+    }
+
+    private static func corruptOneBCPAsset(at packURL: URL) throws {
+        let manifest = try SoundPackPackageValidator.validatePackage(at: packURL)
+        guard let asset = manifest.assets.values.sorted(by: { $0.relativePath < $1.relativePath }).first else {
+            throw HarnessFailure.assertion("fixture BCP pack must contain at least one asset")
+        }
+        let assetURL = packURL.appendingPathComponent(asset.relativePath)
+        try makePCM16MonoFixture(
+            at: assetURL,
+            sampleRate: 48_000,
+            duration: min(asset.durationSeconds + 0.008, 0.16),
+            frequency: 913,
+            peakAmplitude: 0.22
+        )
+    }
+
+    private static func snapshot(packAt packURL: URL) throws -> PackSnapshot {
+        let manifestData = try Data(
+            contentsOf: packURL.appendingPathComponent("manifest.json"),
+            options: [.mappedIfSafe]
+        )
+        let assetURLs = try FileManager.default.contentsOfDirectory(
+            at: packURL.appendingPathComponent("assets", isDirectory: true),
+            includingPropertiesForKeys: nil,
+            options: [.skipsHiddenFiles]
+        ).filter { $0.pathExtension.lowercased() == "wav" }
+        let assetHashes = try Dictionary(
+            uniqueKeysWithValues: assetURLs.map { url in
+                (url.lastPathComponent, try SoundPackFileUtilities.sha256(of: url))
+            }
+        )
+        return PackSnapshot(manifestData: manifestData, assetHashes: assetHashes)
+    }
+
     private static func fakeAsset(id: SoundPackAssetID) -> SoundPackAudioAsset {
         SoundPackAudioAsset(
             id: id,
@@ -1522,6 +2289,95 @@ private struct DIYCoreHarness {
             durationSeconds: 0.1,
             byteCount: 9_644
         )
+    }
+
+    private static func makeBCPInstallerFixtureAssets(
+        at root: URL,
+        variantOffset: Int
+    ) throws {
+        let sampleNames = [
+            "GENERIC_R0",
+            "GENERIC_R0_ALT",
+            "GENERIC_R1",
+            "GENERIC_R1_ALT",
+            "GENERIC_R2",
+            "GENERIC_R2_ALT",
+            "GENERIC_R3",
+            "GENERIC_R3_ALT",
+            "GENERIC_R4",
+            "GENERIC_R4_ALT",
+            "SHIFT",
+            "BACKSPACE",
+            "ENTER",
+            "SPACE",
+        ]
+        let phases = KeySoundPhase.allCases
+        var sampleIndex = 0
+        for phase in phases {
+            for sampleName in sampleNames {
+                let fileURL = root
+                    .appendingPathComponent(phase.rawValue, isDirectory: true)
+                    .appendingPathComponent("\(sampleName).wav")
+                let frequency = 220.0 + Double(sampleIndex * 29 + variantOffset * 11)
+                let duration = 0.040 + Double((sampleIndex + variantOffset) % 5) * 0.008
+                try makePCM16MonoFixture(
+                    at: fileURL,
+                    sampleRate: 48_000,
+                    duration: duration,
+                    frequency: frequency,
+                    peakAmplitude: 0.35
+                )
+                sampleIndex += 1
+            }
+        }
+    }
+
+    private static func makePCM16MonoFixture(
+        at url: URL,
+        sampleRate: Int,
+        duration: Double,
+        frequency: Double,
+        peakAmplitude: Double
+    ) throws {
+        let frameCount = max(Int((Double(sampleRate) * duration).rounded()), 32)
+        var samples = [Int16](repeating: 0, count: frameCount)
+        let denominator = Double(max(frameCount - 1, 1))
+        for index in 0..<frameCount {
+            let envelope = sin(Double.pi * Double(index) / denominator)
+            let sample = sin(2 * Double.pi * frequency * Double(index) / Double(sampleRate))
+                * envelope
+                * peakAmplitude
+            let clipped = max(-1.0, min(1.0, sample))
+            samples[index] = Int16((clipped * Double(Int16.max)).rounded())
+        }
+        samples[0] = 0
+        samples[frameCount - 1] = 0
+
+        let dataByteCount = samples.count * MemoryLayout<Int16>.size
+        var data = Data()
+        data.reserveCapacity(44 + dataByteCount)
+        data.append(contentsOf: "RIFF".utf8)
+        data.appendUInt32LE(UInt32(36 + dataByteCount))
+        data.append(contentsOf: "WAVE".utf8)
+        data.append(contentsOf: "fmt ".utf8)
+        data.appendUInt32LE(16)
+        data.appendUInt16LE(1)
+        data.appendUInt16LE(1)
+        data.appendUInt32LE(UInt32(sampleRate))
+        data.appendUInt32LE(UInt32(sampleRate * MemoryLayout<Int16>.size))
+        data.appendUInt16LE(UInt16(MemoryLayout<Int16>.size))
+        data.appendUInt16LE(16)
+        data.append(contentsOf: "data".utf8)
+        data.appendUInt32LE(UInt32(dataByteCount))
+        for sample in samples {
+            data.appendUInt16LE(UInt16(bitPattern: sample))
+        }
+
+        try FileManager.default.createDirectory(
+            at: url.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try data.write(to: url, options: .atomic)
     }
 
     private static func makeStereoFixture(
@@ -1588,5 +2444,17 @@ private struct DIYCoreHarness {
             try? await Task.sleep(for: .milliseconds(10))
         }
         return FileManager.default.fileExists(atPath: url.path)
+    }
+}
+
+private extension Data {
+    mutating func appendUInt16LE(_ value: UInt16) {
+        var littleEndian = value.littleEndian
+        Swift.withUnsafeBytes(of: &littleEndian) { append(contentsOf: $0) }
+    }
+
+    mutating func appendUInt32LE(_ value: UInt32) {
+        var littleEndian = value.littleEndian
+        Swift.withUnsafeBytes(of: &littleEndian) { append(contentsOf: $0) }
     }
 }

--- a/SimuBoardMac/scripts/install-local-bcp-sound-pack.sh
+++ b/SimuBoardMac/scripts/install-local-bcp-sound-pack.sh
@@ -1,0 +1,919 @@
+#!/bin/zsh
+set -euo pipefail
+
+if (( $# > 2 )); then
+  print -u2 "Usage: $0 [asset-root] [library-root]"
+  exit 64
+fi
+
+SCRIPT_DIR=${0:A:h}
+PROJECT_DIR=${SCRIPT_DIR:h}
+DEFAULT_ASSET_ROOT="$PROJECT_DIR/build/BCP-rendered-assets"
+DEFAULT_LIBRARY_ROOT="$HOME/Library/Application Support/SimuBoard/SoundPacks"
+ASSET_ROOT=${1:-$DEFAULT_ASSET_ROOT}
+LIBRARY_ROOT=${2:-$DEFAULT_LIBRARY_ROOT}
+ASSET_ROOT=${ASSET_ROOT:A}
+DEFAULT_LIBRARY_ROOT=${DEFAULT_LIBRARY_ROOT:A}
+LIBRARY_ROOT=${LIBRARY_ROOT:A}
+
+SHOULD_MIGRATE_LEGACY_SELECTION=0
+if [[ "$LIBRARY_ROOT" == "$DEFAULT_LIBRARY_ROOT" ]]; then
+  SHOULD_MIGRATE_LEGACY_SELECTION=1
+fi
+
+PACK_UUID="15d04652-5265-4ea7-a376-8a7e11ff6813"
+PACK_NAME="BCP (Suit80)"
+PACK_FAMILY="线性"
+PACK_TONE="厚实、木感"
+PACK_LAYOUT_ID="mac-ansi-tkl-v1"
+PACK_BASE_PROFILE_ID="holypanda"
+PACK_SELECTION_ID="custom:15d04652-5265-4ea7-a376-8a7e11ff6813"
+ATTRIBUTION_TITLE="【打字声音】Suit80｜BCP轴｜GMK Ursa 大熊 - Original.mp4"
+ATTRIBUTION_AUTHOR="J_Eason001"
+ATTRIBUTION_NOTICE="Permission unverified. Local evaluation only. Do not redistribute."
+PACK_DIRECTORY_NAME="${PACK_UUID}.simuboardpack"
+DEFAULTS_DOMAIN=${SIMUBOARD_DEFAULTS_DOMAIN:-com.simuboard.mac}
+DEFAULTS_EXECUTABLE=${SIMUBOARD_DEFAULTS_EXECUTABLE:-defaults}
+FAIL_AT=${SIMUBOARD_INSTALLER_FAIL_AT:-}
+TIMESTAMP_OVERRIDE=${SIMUBOARD_INSTALLER_NOW:-}
+
+typeset -a EXPECTED_RECORDS=(
+  'press|GENERIC_R0|row|R0'
+  'press|GENERIC_R1|row|R1'
+  'press|GENERIC_R2|row|R2'
+  'press|GENERIC_R3|row|R3'
+  'press|GENERIC_R4|row|R4'
+  'press|GENERIC_R0_ALT|override|digit2,digit4,digit6,digit8,digit0,equal'
+  'press|GENERIC_R1_ALT|override|w,r,y,i,p,rightBracket'
+  'press|GENERIC_R2_ALT|override|s,f,h,k,semicolon'
+  'press|GENERIC_R3_ALT|override|x,v,n,comma,slash'
+  'press|GENERIC_R4_ALT|override|f2,f4,f6,f8,f10,f12,upArrow,rightArrow'
+  'press|SHIFT|override|leftShift,rightShift'
+  'press|BACKSPACE|special|backspace'
+  'press|ENTER|special|enter'
+  'press|SPACE|special|space'
+  'release|GENERIC_R0|row|R0'
+  'release|GENERIC_R1|row|R1'
+  'release|GENERIC_R2|row|R2'
+  'release|GENERIC_R3|row|R3'
+  'release|GENERIC_R4|row|R4'
+  'release|GENERIC_R0_ALT|override|digit2,digit4,digit6,digit8,digit0,equal'
+  'release|GENERIC_R1_ALT|override|w,r,y,i,p,rightBracket'
+  'release|GENERIC_R2_ALT|override|s,f,h,k,semicolon'
+  'release|GENERIC_R3_ALT|override|x,v,n,comma,slash'
+  'release|GENERIC_R4_ALT|override|f2,f4,f6,f8,f10,f12,upArrow,rightArrow'
+  'release|SHIFT|override|leftShift,rightShift'
+  'release|BACKSPACE|special|backspace'
+  'release|ENTER|special|enter'
+  'release|SPACE|special|space'
+)
+
+typeset -a SHIFT_ONLY_EXPECTED_RECORDS=(
+  'press|GENERIC_R0|row|R0'
+  'press|GENERIC_R1|row|R1'
+  'press|GENERIC_R2|row|R2'
+  'press|GENERIC_R3|row|R3'
+  'press|GENERIC_R4|row|R4'
+  'press|SHIFT|override|leftShift,rightShift'
+  'press|BACKSPACE|special|backspace'
+  'press|ENTER|special|enter'
+  'press|SPACE|special|space'
+  'release|GENERIC_R0|row|R0'
+  'release|GENERIC_R1|row|R1'
+  'release|GENERIC_R2|row|R2'
+  'release|GENERIC_R3|row|R3'
+  'release|GENERIC_R4|row|R4'
+  'release|SHIFT|override|leftShift,rightShift'
+  'release|BACKSPACE|special|backspace'
+  'release|ENTER|special|enter'
+  'release|SPACE|special|space'
+)
+
+typeset -a LEGACY_EXPECTED_RECORDS=(
+  'press|GENERIC_R0|row|R0'
+  'press|GENERIC_R1|row|R1'
+  'press|GENERIC_R2|row|R2'
+  'press|GENERIC_R3|row|R3'
+  'press|GENERIC_R4|row|R4'
+  'press|BACKSPACE|special|backspace'
+  'press|ENTER|special|enter'
+  'press|SPACE|special|space'
+  'release|GENERIC_R0|row|R0'
+  'release|GENERIC_R1|row|R1'
+  'release|GENERIC_R2|row|R2'
+  'release|GENERIC_R3|row|R3'
+  'release|GENERIC_R4|row|R4'
+  'release|BACKSPACE|special|backspace'
+  'release|ENTER|special|enter'
+  'release|SPACE|special|space'
+)
+
+typeset -a EXPECTED_OVERRIDE_KEYS=(
+  digit2 digit4 digit6 digit8 digit0 equal
+  w r y i p rightBracket
+  s f h k semicolon
+  x v n comma slash
+  f2 f4 f6 f8 f10 f12 upArrow rightArrow
+  leftShift rightShift
+)
+
+typeset -a SHIFT_ONLY_OVERRIDE_KEYS=(leftShift rightShift)
+
+STAT_BIN=/usr/bin/stat
+if [[ ! -x "$STAT_BIN" ]]; then
+  STAT_BIN=$(command -v stat || true)
+fi
+
+DESTINATION_PACK="$LIBRARY_ROOT/$PACK_DIRECTORY_NAME"
+STAGE_ROOT=""
+STAGED_PACK_ROOT=""
+BACKUP_PACK_ROOT=""
+ASSET_LINES=""
+PRESS_ROWS_LINES=""
+PRESS_SPECIALS_LINES=""
+PRESS_OVERRIDES_LINES=""
+RELEASE_ROWS_LINES=""
+RELEASE_SPECIALS_LINES=""
+RELEASE_OVERRIDES_LINES=""
+ASSETS_OBJECT_FILE=""
+PRESS_ROWS_FILE=""
+PRESS_SPECIALS_FILE=""
+PRESS_OVERRIDES_FILE=""
+RELEASE_ROWS_FILE=""
+RELEASE_SPECIALS_FILE=""
+RELEASE_OVERRIDES_FILE=""
+TARGET_FINGERPRINT_FILE=""
+EXISTING_CREATED_AT=""
+EXISTING_MODIFIED_AT=""
+EXISTING_FINGERPRINT=""
+PREVIOUS_PACK_PRESENT=0
+BACKUP_CREATED=0
+DESTINATION_INSTALLED=0
+INSTALL_COMMITTED=0
+
+fail() {
+  print -u2 "$1"
+  exit "${2:-65}"
+}
+
+warn() {
+  print -u2 "Warning: $1"
+}
+
+cleanup_on_exit() {
+  local exit_status=$1
+  local rollback_failed=0
+
+  if (( INSTALL_COMMITTED == 0 )); then
+    rollback_installation || rollback_failed=1
+  elif (( BACKUP_CREATED == 1 )) && [[ -e "$BACKUP_PACK_ROOT" ]]; then
+    rm -rf "$BACKUP_PACK_ROOT"
+    BACKUP_CREATED=0
+  fi
+
+  if [[ -n "$STAGE_ROOT" && -d "$STAGE_ROOT" ]]; then
+    rm -rf "$STAGE_ROOT"
+  fi
+
+  if (( rollback_failed == 1 )); then
+    warn "Manual recovery may be required for $DESTINATION_PACK"
+  fi
+  exit "$exit_status"
+}
+trap 'cleanup_on_exit $?' EXIT
+
+for command_name in ffmpeg ffprobe jq shasum od date; do
+  if ! command -v "$command_name" >/dev/null 2>&1; then
+    fail "Missing required command: $command_name" 69
+  fi
+done
+[[ -n "$STAT_BIN" ]] || fail "Missing required command: stat" 69
+
+file_size_bytes() {
+  local path=$1
+
+  if "$STAT_BIN" -f '%z' "$path" >/dev/null 2>&1; then
+    "$STAT_BIN" -f '%z' "$path"
+  else
+    "$STAT_BIN" -c '%s' "$path"
+  fi
+}
+
+sha256_of() {
+  local checksum
+
+  checksum=$(shasum -a 256 "$1")
+  print -- "${checksum%% *}"
+}
+
+installer_timestamp() {
+  if [[ -n "$TIMESTAMP_OVERRIDE" ]]; then
+    print -- "$TIMESTAMP_OVERRIDE"
+  else
+    date -u +%Y-%m-%dT%H:%M:%SZ
+  fi
+}
+
+maybe_fail_at() {
+  local point=$1
+
+  if [[ "$FAIL_AT" == "$point" ]]; then
+    fail "Injected installer failure at $point" 73
+  fi
+}
+
+ensure_safe_directory_root() {
+  local path=$1
+
+  case "$path" in
+    ''|/|/private|/tmp|/private/tmp)
+      fail "Refusing unsafe destination root: $path"
+      ;;
+  esac
+}
+
+ensure_directory_root_ready() {
+  ensure_safe_directory_root "$LIBRARY_ROOT"
+
+  if [[ -e "$LIBRARY_ROOT" && ! -d "$LIBRARY_ROOT" ]]; then
+    fail "Library root is not a directory: $LIBRARY_ROOT"
+  fi
+  if [[ -L "$LIBRARY_ROOT" ]]; then
+    fail "Library root must not be a symlink: $LIBRARY_ROOT"
+  fi
+  mkdir -p "$LIBRARY_ROOT"
+}
+
+setup_work_paths() {
+  local backup_suffix
+
+  STAGE_ROOT=$(mktemp -d "$LIBRARY_ROOT/.bcp-pack-staging.XXXXXX")
+  STAGED_PACK_ROOT="$STAGE_ROOT/$PACK_DIRECTORY_NAME"
+  ASSET_LINES="$STAGE_ROOT/assets.jsonl"
+  PRESS_ROWS_LINES="$STAGE_ROOT/press-rows.jsonl"
+  PRESS_SPECIALS_LINES="$STAGE_ROOT/press-specials.jsonl"
+  PRESS_OVERRIDES_LINES="$STAGE_ROOT/press-overrides.jsonl"
+  RELEASE_ROWS_LINES="$STAGE_ROOT/release-rows.jsonl"
+  RELEASE_SPECIALS_LINES="$STAGE_ROOT/release-specials.jsonl"
+  RELEASE_OVERRIDES_LINES="$STAGE_ROOT/release-overrides.jsonl"
+  ASSETS_OBJECT_FILE="$STAGE_ROOT/assets-object.json"
+  PRESS_ROWS_FILE="$STAGE_ROOT/press-rows.json"
+  PRESS_SPECIALS_FILE="$STAGE_ROOT/press-specials.json"
+  PRESS_OVERRIDES_FILE="$STAGE_ROOT/press-overrides.json"
+  RELEASE_ROWS_FILE="$STAGE_ROOT/release-rows.json"
+  RELEASE_SPECIALS_FILE="$STAGE_ROOT/release-specials.json"
+  RELEASE_OVERRIDES_FILE="$STAGE_ROOT/release-overrides.json"
+  TARGET_FINGERPRINT_FILE="$STAGE_ROOT/target-fingerprint.json"
+
+  backup_suffix="${$}-$(date -u +%Y%m%d%H%M%S)"
+  BACKUP_PACK_ROOT="$LIBRARY_ROOT/.${PACK_UUID}.backup-${backup_suffix}.simuboardpack"
+  while [[ -e "$BACKUP_PACK_ROOT" ]]; do
+    backup_suffix="${backup_suffix}x"
+    BACKUP_PACK_ROOT="$LIBRARY_ROOT/.${PACK_UUID}.backup-${backup_suffix}.simuboardpack"
+  done
+}
+
+ensure_exact_asset_tree() {
+  local -a expected_paths=()
+  local -a actual_paths=()
+  local record phase sample_name relative_path sample_file
+
+  for record in "${EXPECTED_RECORDS[@]}"; do
+    IFS='|' read -r phase sample_name _ <<< "$record"
+    expected_paths+=("$phase/$sample_name.wav")
+  done
+
+  while IFS= read -r sample_file; do
+    [[ -n "$sample_file" ]] || continue
+    relative_path=${sample_file#$ASSET_ROOT/}
+    actual_paths+=("$relative_path")
+  done < <(find "$ASSET_ROOT" -type f | LC_ALL=C sort)
+
+  if [[ "$(printf '%s\n' "${actual_paths[@]}")" != "$(printf '%s\n' "${expected_paths[@]}" | LC_ALL=C sort)" ]]; then
+    print -u2 "Unexpected asset tree under $ASSET_ROOT"
+    print -u2 "Expected:"
+    printf '%s\n' "${expected_paths[@]}" | LC_ALL=C sort >&2
+    print -u2 "Actual:"
+    printf '%s\n' "${actual_paths[@]}" >&2
+    exit 65
+  fi
+}
+
+validate_audio_file() {
+  local file=$1
+  local relative_path=$2
+  local metadata codec_name sample_rate channels bits_per_sample duration_seconds byte_count last_sample
+
+  metadata=$(ffprobe \
+    -v error \
+    -of json \
+    -show_entries stream=codec_name,sample_rate,channels,bits_per_sample:format=duration \
+    "$file")
+  codec_name=$(jq -r '.streams[0].codec_name // empty' <<< "$metadata")
+  sample_rate=$(jq -r '.streams[0].sample_rate // empty' <<< "$metadata")
+  channels=$(jq -r '.streams[0].channels // empty' <<< "$metadata")
+  bits_per_sample=$(jq -r '.streams[0].bits_per_sample // empty' <<< "$metadata")
+  duration_seconds=$(jq -r '.format.duration // empty' <<< "$metadata")
+
+  [[ "$codec_name" == "pcm_s16le" ]] || fail "Unexpected codec for $relative_path: $codec_name"
+  [[ "$sample_rate" == "48000" ]] || fail "Unexpected sample rate for $relative_path: $sample_rate"
+  [[ "$channels" == "1" ]] || fail "Unexpected channel count for $relative_path: $channels"
+  [[ "$bits_per_sample" == "16" ]] || fail "Unexpected bit depth for $relative_path: $bits_per_sample"
+  awk "BEGIN { exit !($duration_seconds >= 0.005 && $duration_seconds <= 5.0) }" \
+    || fail "Audio duration out of range for $relative_path: $duration_seconds"
+
+  byte_count=$(file_size_bytes "$file")
+  (( byte_count > 0 )) || fail "Audio file is empty: $relative_path"
+
+  last_sample=$(ffmpeg \
+    -hide_banner \
+    -loglevel error \
+    -nostdin \
+    -i "$file" \
+    -f s16le \
+    -ac 1 \
+    -ar 48000 \
+    - 2>/dev/null \
+    | tail -c 2 \
+    | od -An -td2 \
+    | tr -d '[:space:]')
+  [[ "$last_sample" == "0" ]] || fail "Audio must end on an exact zero sample: $relative_path"
+
+  print -- "$duration_seconds|$byte_count"
+}
+
+append_assignment() {
+  local phase=$1
+  local assignment_kind=$2
+  local assignment_key=$3
+  local asset_id=$4
+  local target_file override_key
+
+  case "$phase:$assignment_kind" in
+    press:row) target_file=$PRESS_ROWS_LINES ;;
+    press:special) target_file=$PRESS_SPECIALS_LINES ;;
+    press:override) target_file=$PRESS_OVERRIDES_LINES ;;
+    release:row) target_file=$RELEASE_ROWS_LINES ;;
+    release:special) target_file=$RELEASE_SPECIALS_LINES ;;
+    release:override) target_file=$RELEASE_OVERRIDES_LINES ;;
+    *) fail "Unknown assignment bucket: $phase/$assignment_kind" ;;
+  esac
+
+  if [[ "$assignment_kind" == override ]]; then
+    for override_key in ${(s:,:)assignment_key}; do
+      jq -n \
+        --arg key "$override_key" \
+        --arg assetID "$asset_id" \
+        '{key: $key, value: {kind: "asset", assetID: $assetID}}' >> "$target_file"
+    done
+  else
+    jq -n \
+      --arg key "$assignment_key" \
+      --arg value "$asset_id" \
+      '{key: $key, value: $value}' >> "$target_file"
+  fi
+}
+
+build_manifest_maps() {
+  jq -sS 'reduce .[] as $item ({}; .[$item.id] = $item)' "$ASSET_LINES" > "$ASSETS_OBJECT_FILE"
+  jq -sS 'reduce .[] as $item ({}; .[$item.key] = $item.value)' "$PRESS_ROWS_LINES" > "$PRESS_ROWS_FILE"
+  jq -sS 'reduce .[] as $item ({}; .[$item.key] = $item.value)' "$PRESS_SPECIALS_LINES" > "$PRESS_SPECIALS_FILE"
+  jq -sS 'reduce .[] as $item ({}; .[$item.key] = $item.value)' "$PRESS_OVERRIDES_LINES" > "$PRESS_OVERRIDES_FILE"
+  jq -sS 'reduce .[] as $item ({}; .[$item.key] = $item.value)' "$RELEASE_ROWS_LINES" > "$RELEASE_ROWS_FILE"
+  jq -sS 'reduce .[] as $item ({}; .[$item.key] = $item.value)' "$RELEASE_SPECIALS_LINES" > "$RELEASE_SPECIALS_FILE"
+  jq -sS 'reduce .[] as $item ({}; .[$item.key] = $item.value)' "$RELEASE_OVERRIDES_LINES" > "$RELEASE_OVERRIDES_FILE"
+}
+
+build_target_fingerprint() {
+  jq -ncS \
+    --arg packID "$PACK_UUID" \
+    --arg name "$PACK_NAME" \
+    --arg family "$PACK_FAMILY" \
+    --arg tone "$PACK_TONE" \
+    --arg layoutID "$PACK_LAYOUT_ID" \
+    --arg baseProfileID "$PACK_BASE_PROFILE_ID" \
+    --arg title "$ATTRIBUTION_TITLE" \
+    --arg author "$ATTRIBUTION_AUTHOR" \
+    --arg notice "$ATTRIBUTION_NOTICE" \
+    --slurpfile assets "$ASSETS_OBJECT_FILE" \
+    --slurpfile pressRows "$PRESS_ROWS_FILE" \
+    --slurpfile pressSpecials "$PRESS_SPECIALS_FILE" \
+    --slurpfile pressOverrides "$PRESS_OVERRIDES_FILE" \
+    --slurpfile releaseRows "$RELEASE_ROWS_FILE" \
+    --slurpfile releaseSpecials "$RELEASE_SPECIALS_FILE" \
+    --slurpfile releaseOverrides "$RELEASE_OVERRIDES_FILE" \
+    '{
+      schemaVersion: 1,
+      id: $packID,
+      name: $name,
+      author: null,
+      family: $family,
+      tone: $tone,
+      notes: null,
+      baseProfileID: $baseProfileID,
+      layoutID: $layoutID,
+      press: {
+        generic: null,
+        rows: $pressRows[0],
+        specials: $pressSpecials[0],
+        keyOverrides: $pressOverrides[0]
+      },
+      release: {
+        generic: null,
+        rows: $releaseRows[0],
+        specials: $releaseSpecials[0],
+        keyOverrides: $releaseOverrides[0]
+      },
+      assets: $assets[0],
+      attributions: [
+        {
+          title: $title,
+          author: $author,
+          sourceURL: null,
+          licenseName: null,
+          notice: $notice
+        }
+      ]
+    }' > "$TARGET_FINGERPRINT_FILE"
+}
+
+validate_manifest_file() {
+  local manifest_path=$1
+  local context_message=$2
+
+  [[ -f "$manifest_path" ]] || fail "$context_message"
+  [[ ! -L "$manifest_path" ]] || fail "$context_message"
+  jq -e . "$manifest_path" >/dev/null 2>&1 || fail "$context_message"
+}
+
+validate_iso8601_utc_timestamp() {
+  local timestamp=$1
+  local roundtrip=""
+
+  [[ "$timestamp" =~ '^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$' ]] || return 1
+  roundtrip=$(date -u -j -f '%Y-%m-%dT%H:%M:%SZ' "$timestamp" '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null) \
+    || return 1
+  [[ "$roundtrip" == "$timestamp" ]]
+}
+
+manifest_fingerprint_of() {
+  local manifest_path=$1
+
+  jq -cS \
+    '{schemaVersion,id,name,author,family,tone,notes,baseProfileID,layoutID,press,release,assets,attributions}' \
+    "$manifest_path"
+}
+
+validate_fixed_bcp_pack() {
+  local pack_root=$1
+  local context_message=$2
+  local allow_legacy=${3:-0}
+  local manifest_path=$pack_root/manifest.json
+  local assets_root=$pack_root/assets
+  local created_at modified_at top_level_listing asset_listing finder_metadata_path
+  local -i expected_count=28
+  local -A seen_asset_ids=()
+  local -a expected_asset_paths=()
+  local -a validation_records=("${EXPECTED_RECORDS[@]}")
+  local -a expected_override_keys=("${EXPECTED_OVERRIDE_KEYS[@]}")
+  local record phase sample_name assignment_kind assignment_key asset_id asset_relative_path
+  local first_override_key override_key mapped_asset_id
+  local original_filename asset_file validation actual_duration actual_byte_count manifest_duration
+  local manifest_byte_count asset_sha expected_override_keys_json
+
+  [[ -d "$pack_root" ]] || fail "$context_message"
+  [[ ! -L "$pack_root" ]] || fail "$context_message"
+  [[ "${pack_root##*/}" == "$PACK_DIRECTORY_NAME" ]] || fail "$context_message"
+  [[ -d "$assets_root" ]] || fail "$context_message"
+  [[ ! -L "$assets_root" ]] || fail "$context_message"
+
+  validate_manifest_file "$manifest_path" "$context_message"
+
+  if (( allow_legacy )) && jq -e '
+    (.assets | type == "object" and length == 16)
+    and (.press.keyOverrides == {})
+    and (.release.keyOverrides == {})
+  ' "$manifest_path" >/dev/null 2>&1; then
+    expected_count=16
+    validation_records=("${LEGACY_EXPECTED_RECORDS[@]}")
+    expected_override_keys=()
+  elif (( allow_legacy )) && jq -e '
+    (.assets | type == "object" and length == 18)
+    and ((.press.keyOverrides | keys | sort) == ["leftShift","rightShift"])
+    and ((.release.keyOverrides | keys | sort) == ["leftShift","rightShift"])
+  ' "$manifest_path" >/dev/null 2>&1; then
+    expected_count=18
+    validation_records=("${SHIFT_ONLY_EXPECTED_RECORDS[@]}")
+    expected_override_keys=("${SHIFT_ONLY_OVERRIDE_KEYS[@]}")
+  fi
+
+  expected_override_keys_json=$(jq -nc --args \
+    '$ARGS.positional | sort' "${expected_override_keys[@]}") || fail "$context_message"
+
+  jq -e \
+    --argjson expectedAssetCount "$expected_count" \
+    --argjson expectedOverrideKeys "$expected_override_keys_json" \
+    --arg packID "$PACK_UUID" \
+    --arg name "$PACK_NAME" \
+    --arg family "$PACK_FAMILY" \
+    --arg tone "$PACK_TONE" \
+    --arg layoutID "$PACK_LAYOUT_ID" \
+    --arg baseProfileID "$PACK_BASE_PROFILE_ID" \
+    --arg title "$ATTRIBUTION_TITLE" \
+    --arg author "$ATTRIBUTION_AUTHOR" \
+    --arg notice "$ATTRIBUTION_NOTICE" \
+    '
+      (.schemaVersion == 1)
+      and (.id == $packID)
+      and (.name == $name)
+      and (.author == null)
+      and (.family == $family)
+      and (.tone == $tone)
+      and (.notes == null)
+      and (.baseProfileID == $baseProfileID)
+      and (.layoutID == $layoutID)
+      and (.createdAt | type == "string")
+      and (.modifiedAt | type == "string")
+      and (.press | type == "object")
+      and (.release | type == "object")
+      and ((.press | keys | sort) == ["generic","keyOverrides","rows","specials"])
+      and ((.release | keys | sort) == ["generic","keyOverrides","rows","specials"])
+      and (.press.generic == null)
+      and (.release.generic == null)
+      and ((.press.keyOverrides | keys | sort) == $expectedOverrideKeys)
+      and ((.release.keyOverrides | keys | sort) == $expectedOverrideKeys)
+      and (all(.press.keyOverrides[]; .kind == "asset"))
+      and (all(.release.keyOverrides[]; .kind == "asset"))
+      and ((.press.rows | type == "object" and (keys | sort) == ["R0","R1","R2","R3","R4"]))
+      and ((.release.rows | type == "object" and (keys | sort) == ["R0","R1","R2","R3","R4"]))
+      and ((.press.specials | type == "object" and (keys | sort) == ["backspace","enter","space"]))
+      and ((.release.specials | type == "object" and (keys | sort) == ["backspace","enter","space"]))
+      and (.assets | type == "object" and length == $expectedAssetCount)
+      and (.attributions == [{
+        title: $title,
+        author: $author,
+        sourceURL: null,
+        licenseName: null,
+        notice: $notice
+      }])
+    ' "$manifest_path" >/dev/null 2>&1 || fail "$context_message"
+
+  created_at=$(jq -r '.createdAt' "$manifest_path") || fail "$context_message"
+  modified_at=$(jq -r '.modifiedAt' "$manifest_path") || fail "$context_message"
+  validate_iso8601_utc_timestamp "$created_at" || fail "$context_message"
+  validate_iso8601_utc_timestamp "$modified_at" || fail "$context_message"
+
+  for finder_metadata_path in "$pack_root/.DS_Store" "$assets_root/.DS_Store"; do
+    if [[ -e "$finder_metadata_path" || -L "$finder_metadata_path" ]]; then
+      [[ -f "$finder_metadata_path" && ! -L "$finder_metadata_path" ]] || fail "$context_message"
+    fi
+  done
+
+  top_level_listing=$(find "$pack_root" -mindepth 1 -maxdepth 1 ! -name '.DS_Store' -print | LC_ALL=C sort)
+  [[ "$top_level_listing" == $pack_root/assets$'\n'$pack_root/manifest.json ]] || fail "$context_message"
+
+  for record in "${validation_records[@]}"; do
+    IFS='|' read -r phase sample_name assignment_kind assignment_key <<< "$record"
+    case "$assignment_kind" in
+      row)
+        asset_id=$(jq -r --arg phase "$phase" --arg key "$assignment_key" '
+          if $phase == "press" then .press.rows[$key] else .release.rows[$key] end // empty
+        ' "$manifest_path") || fail "$context_message"
+        ;;
+      special)
+        asset_id=$(jq -r --arg phase "$phase" --arg key "$assignment_key" '
+          if $phase == "press" then .press.specials[$key] else .release.specials[$key] end // empty
+        ' "$manifest_path") || fail "$context_message"
+        ;;
+      override)
+        first_override_key=${assignment_key%%,*}
+        asset_id=$(jq -r --arg phase "$phase" --arg key "$first_override_key" '
+          if $phase == "press"
+          then .press.keyOverrides[$key].assetID
+          else .release.keyOverrides[$key].assetID
+          end // empty
+        ' "$manifest_path") || fail "$context_message"
+        for override_key in ${(s:,:)assignment_key}; do
+          mapped_asset_id=$(jq -r --arg phase "$phase" --arg key "$override_key" '
+            if $phase == "press"
+            then .press.keyOverrides[$key].assetID
+            else .release.keyOverrides[$key].assetID
+            end // empty
+          ' "$manifest_path") || fail "$context_message"
+          [[ "$mapped_asset_id" == "$asset_id" ]] || fail "$context_message"
+        done
+        ;;
+      *) fail "$context_message" ;;
+    esac
+
+    [[ "$asset_id" =~ '^[0-9a-f]{64}$' ]] || fail "$context_message"
+    [[ -z "${seen_asset_ids[$asset_id]-}" ]] || fail "$context_message"
+    seen_asset_ids[$asset_id]=1
+
+    asset_relative_path="assets/$asset_id.wav"
+    original_filename="$phase/$sample_name.wav"
+    expected_asset_paths+=("$asset_relative_path")
+    jq -e \
+      --arg id "$asset_id" \
+      --arg relativePath "$asset_relative_path" \
+      --arg originalFilename "$original_filename" \
+      '
+        .assets[$id]
+        and ((.assets[$id] | keys | sort) == [
+          "byteCount",
+          "channelCount",
+          "durationSeconds",
+          "id",
+          "license",
+          "originalFilename",
+          "relativePath",
+          "sampleRate",
+          "sha256"
+        ])
+        and (.assets[$id].id == $id)
+        and (.assets[$id].sha256 == $id)
+        and (.assets[$id].relativePath == $relativePath)
+        and (.assets[$id].originalFilename == $originalFilename)
+        and (.assets[$id].sampleRate == 48000)
+        and (.assets[$id].channelCount == 1)
+        and (.assets[$id].license == null)
+        and (.assets[$id].durationSeconds | type == "number" and . >= 0.005 and . <= 5)
+        and (.assets[$id].byteCount | type == "number" and . > 0)
+      ' "$manifest_path" >/dev/null 2>&1 || fail "$context_message"
+
+    asset_file="$pack_root/$asset_relative_path"
+    [[ -f "$asset_file" ]] || fail "$context_message"
+    [[ ! -L "$asset_file" ]] || fail "$context_message"
+
+    validation=$(validate_audio_file "$asset_file" "$asset_relative_path")
+    actual_duration=${validation%%|*}
+    actual_byte_count=${validation##*|}
+    manifest_duration=$(jq -r --arg id "$asset_id" '.assets[$id].durationSeconds' "$manifest_path") \
+      || fail "$context_message"
+    manifest_byte_count=$(jq -r --arg id "$asset_id" '.assets[$id].byteCount' "$manifest_path") \
+      || fail "$context_message"
+    awk "BEGIN { diff = $actual_duration - $manifest_duration; if (diff < 0) diff = -diff; exit !(diff < 0.002) }" \
+      || fail "$context_message"
+    [[ "$actual_byte_count" == "$manifest_byte_count" ]] || fail "$context_message"
+
+    asset_sha=$(sha256_of "$asset_file")
+    [[ "$asset_sha" == "$asset_id" ]] || fail "$context_message"
+  done
+
+  (( ${#seen_asset_ids} == expected_count )) || fail "$context_message"
+  [[ "$(jq -r '.assets | keys | length' "$manifest_path")" == "$expected_count" ]] || fail "$context_message"
+
+  asset_listing=$(find "$assets_root" -mindepth 1 -maxdepth 1 ! -name '.DS_Store' -print | LC_ALL=C sort)
+  [[ "$asset_listing" == "$(printf '%s\n' "${expected_asset_paths[@]}" | sed "s#^#$pack_root/#" | LC_ALL=C sort)" ]] \
+    || fail "$context_message"
+}
+
+read_existing_pack_state() {
+  local manifest_path
+
+  if [[ ! -e "$DESTINATION_PACK" ]]; then
+    PREVIOUS_PACK_PRESENT=0
+    return
+  fi
+
+  [[ -d "$DESTINATION_PACK" ]] || fail "Existing BCP pack path is not a directory: $DESTINATION_PACK"
+  [[ ! -L "$DESTINATION_PACK" ]] || fail "Existing BCP pack path must not be a symlink: $DESTINATION_PACK"
+
+  validate_fixed_bcp_pack "$DESTINATION_PACK" \
+    "Existing fixed BCP pack is invalid and will not be overwritten" \
+    1
+
+  PREVIOUS_PACK_PRESENT=1
+  manifest_path="$DESTINATION_PACK/manifest.json"
+  EXISTING_CREATED_AT=$(jq -r '.createdAt' "$manifest_path")
+  EXISTING_MODIFIED_AT=$(jq -r '.modifiedAt' "$manifest_path")
+  EXISTING_FINGERPRINT=$(manifest_fingerprint_of "$manifest_path") \
+    || fail "Existing fixed BCP pack manifest could not be fingerprinted"
+}
+
+write_manifest() {
+  local created_at=$1
+  local modified_at=$2
+
+  jq -nS \
+    --arg packID "$PACK_UUID" \
+    --arg name "$PACK_NAME" \
+    --arg family "$PACK_FAMILY" \
+    --arg tone "$PACK_TONE" \
+    --arg layoutID "$PACK_LAYOUT_ID" \
+    --arg baseProfileID "$PACK_BASE_PROFILE_ID" \
+    --arg createdAt "$created_at" \
+    --arg modifiedAt "$modified_at" \
+    --arg title "$ATTRIBUTION_TITLE" \
+    --arg author "$ATTRIBUTION_AUTHOR" \
+    --arg notice "$ATTRIBUTION_NOTICE" \
+    --slurpfile assets "$ASSETS_OBJECT_FILE" \
+    --slurpfile pressRows "$PRESS_ROWS_FILE" \
+    --slurpfile pressSpecials "$PRESS_SPECIALS_FILE" \
+    --slurpfile pressOverrides "$PRESS_OVERRIDES_FILE" \
+    --slurpfile releaseRows "$RELEASE_ROWS_FILE" \
+    --slurpfile releaseSpecials "$RELEASE_SPECIALS_FILE" \
+    --slurpfile releaseOverrides "$RELEASE_OVERRIDES_FILE" \
+    '{
+      schemaVersion: 1,
+      id: $packID,
+      name: $name,
+      author: null,
+      family: $family,
+      tone: $tone,
+      notes: null,
+      baseProfileID: $baseProfileID,
+      layoutID: $layoutID,
+      createdAt: $createdAt,
+      modifiedAt: $modifiedAt,
+      press: {
+        generic: null,
+        rows: $pressRows[0],
+        specials: $pressSpecials[0],
+        keyOverrides: $pressOverrides[0]
+      },
+      release: {
+        generic: null,
+        rows: $releaseRows[0],
+        specials: $releaseSpecials[0],
+        keyOverrides: $releaseOverrides[0]
+      },
+      assets: $assets[0],
+      attributions: [
+        {
+          title: $title,
+          author: $author,
+          sourceURL: null,
+          licenseName: null,
+          notice: $notice
+        }
+      ]
+    }' > "$STAGED_PACK_ROOT/manifest.json"
+}
+
+rollback_installation() {
+  local displaced_destination=""
+
+  if (( PREVIOUS_PACK_PRESENT == 1 )); then
+    if (( DESTINATION_INSTALLED == 1 )) && [[ -e "$DESTINATION_PACK" ]]; then
+      displaced_destination="$STAGE_ROOT/rollback-failed-install.simuboardpack"
+      if ! mv "$DESTINATION_PACK" "$displaced_destination"; then
+        warn "Rollback could not move the partial BCP pack out of the destination."
+        if (( BACKUP_CREATED == 1 )) && [[ -e "$BACKUP_PACK_ROOT" ]]; then
+          warn "Recover the previous BCP pack from: $BACKUP_PACK_ROOT"
+        fi
+        return 1
+      fi
+    fi
+
+    if (( BACKUP_CREATED == 1 )) && [[ -e "$BACKUP_PACK_ROOT" ]]; then
+      if mv "$BACKUP_PACK_ROOT" "$DESTINATION_PACK"; then
+        BACKUP_CREATED=0
+        DESTINATION_INSTALLED=0
+        return 0
+      fi
+      warn "Rollback could not restore the previous BCP pack."
+      warn "Recover the previous BCP pack from: $BACKUP_PACK_ROOT"
+      return 1
+    fi
+
+    warn "Rollback could not find the previous BCP backup."
+    return 1
+  fi
+
+  if (( DESTINATION_INSTALLED == 1 )) && [[ -e "$DESTINATION_PACK" ]]; then
+    if ! mv "$DESTINATION_PACK" "$STAGE_ROOT/rollback-abandoned-install.simuboardpack"; then
+      warn "Rollback could not remove the partially installed BCP pack: $DESTINATION_PACK"
+      return 1
+    fi
+    DESTINATION_INSTALLED=0
+  fi
+
+  return 0
+}
+
+publish_pack() {
+  mkdir -p "$LIBRARY_ROOT"
+  validate_fixed_bcp_pack "$STAGED_PACK_ROOT" \
+    "Staged fixed BCP pack is invalid before installation"
+
+  if (( PREVIOUS_PACK_PRESENT == 1 )); then
+    mv "$DESTINATION_PACK" "$BACKUP_PACK_ROOT"
+    BACKUP_CREATED=1
+    maybe_fail_at "after-backup"
+  fi
+
+  mv "$STAGED_PACK_ROOT" "$DESTINATION_PACK"
+  DESTINATION_INSTALLED=1
+  maybe_fail_at "after-install-before-commit"
+
+  validate_fixed_bcp_pack "$DESTINATION_PACK" \
+    "Installed fixed BCP pack is invalid after installation"
+
+  INSTALL_COMMITTED=1
+  if (( BACKUP_CREATED == 1 )) && [[ -e "$BACKUP_PACK_ROOT" ]]; then
+    rm -rf "$BACKUP_PACK_ROOT"
+    BACKUP_CREATED=0
+  fi
+}
+
+migrate_legacy_selection_if_needed() {
+  local selected_profile=""
+
+  if (( SHOULD_MIGRATE_LEGACY_SELECTION == 0 )); then
+    return
+  fi
+
+  if ! command -v "$DEFAULTS_EXECUTABLE" >/dev/null 2>&1; then
+    warn "Installed the BCP pack but could not find '$DEFAULTS_EXECUTABLE' to migrate the legacy selection."
+    return
+  fi
+
+  if ! selected_profile=$("$DEFAULTS_EXECUTABLE" read "$DEFAULTS_DOMAIN" selectedProfile 2>/dev/null); then
+    return
+  fi
+  selected_profile=${selected_profile//$'\n'/}
+
+  if [[ "$selected_profile" == "bcp" ]]; then
+    if ! "$DEFAULTS_EXECUTABLE" write "$DEFAULTS_DOMAIN" selectedProfile -string "$PACK_SELECTION_ID" >/dev/null 2>&1; then
+      warn "Installed the BCP pack, but could not migrate '$DEFAULTS_DOMAIN' from 'bcp' to '$PACK_SELECTION_ID'."
+    fi
+  fi
+}
+
+[[ -d "$ASSET_ROOT" ]] || fail "Missing asset root: $ASSET_ROOT" 66
+ensure_directory_root_ready
+setup_work_paths
+ensure_exact_asset_tree
+read_existing_pack_state
+
+mkdir -p "$STAGED_PACK_ROOT/assets"
+: > "$ASSET_LINES"
+: > "$PRESS_ROWS_LINES"
+: > "$PRESS_SPECIALS_LINES"
+: > "$PRESS_OVERRIDES_LINES"
+: > "$RELEASE_ROWS_LINES"
+: > "$RELEASE_SPECIALS_LINES"
+: > "$RELEASE_OVERRIDES_LINES"
+
+typeset -A SEEN_HASHES
+for record in "${EXPECTED_RECORDS[@]}"; do
+  IFS='|' read -r phase sample_name assignment_kind assignment_key <<< "$record"
+  source_file="$ASSET_ROOT/$phase/$sample_name.wav"
+  relative_path="$phase/$sample_name.wav"
+  [[ -f "$source_file" ]] || fail "Missing expected asset: $relative_path" 66
+
+  validation=$(validate_audio_file "$source_file" "$relative_path")
+  duration_seconds=${validation%%|*}
+  byte_count=${validation##*|}
+  asset_id=$(sha256_of "$source_file")
+  [[ "$asset_id" =~ '^[0-9a-f]{64}$' ]] || fail "Asset hash must be lowercase SHA-256: $relative_path"
+  [[ -z "${SEEN_HASHES[$asset_id]-}" ]] || fail "Duplicate asset content hash detected for $relative_path"
+  SEEN_HASHES[$asset_id]=1
+
+  staged_asset="$STAGED_PACK_ROOT/assets/$asset_id.wav"
+  cp "$source_file" "$staged_asset"
+
+  jq -n \
+    --arg id "$asset_id" \
+    --arg relativePath "assets/$asset_id.wav" \
+    --arg originalFilename "$relative_path" \
+    --argjson durationSeconds "$duration_seconds" \
+    --argjson byteCount "$byte_count" \
+    '{
+      id: $id,
+      relativePath: $relativePath,
+      sha256: $id,
+      originalFilename: $originalFilename,
+      durationSeconds: $durationSeconds,
+      sampleRate: 48000,
+      channelCount: 1,
+      byteCount: $byteCount,
+      license: null
+    }' >> "$ASSET_LINES"
+
+  append_assignment "$phase" "$assignment_kind" "$assignment_key" "$asset_id"
+done
+
+(( ${#SEEN_HASHES} == ${#EXPECTED_RECORDS} )) \
+  || fail "Expected ${#EXPECTED_RECORDS} unique rendered assets, found ${#SEEN_HASHES}"
+build_manifest_maps
+build_target_fingerprint
+
+install_time=$(installer_timestamp)
+created_at="$install_time"
+modified_at="$install_time"
+if (( PREVIOUS_PACK_PRESENT == 1 )); then
+  created_at="$EXISTING_CREATED_AT"
+  current_fingerprint=$(cat "$TARGET_FINGERPRINT_FILE")
+  if [[ "$current_fingerprint" == "$EXISTING_FINGERPRINT" ]]; then
+    modified_at="$EXISTING_MODIFIED_AT"
+  fi
+fi
+
+write_manifest "$created_at" "$modified_at"
+publish_pack
+migrate_legacy_selection_if_needed
+
+print "Installed local BCP pack to $DESTINATION_PACK"
+print "Validated ${#EXPECTED_RECORDS} rendered assets from $ASSET_ROOT"

--- a/SimuBoardMac/scripts/render-local-bcp-profile.sh
+++ b/SimuBoardMac/scripts/render-local-bcp-profile.sh
@@ -1,0 +1,667 @@
+#!/bin/zsh
+set -euo pipefail
+
+if (( $# != 1 )); then
+  print -u2 "Usage: $0 <source-mp4>"
+  exit 64
+fi
+
+SOURCE_VIDEO=${1:A}
+SCRIPT_DIR=${0:A:h}
+PROJECT_DIR=${SCRIPT_DIR:h}
+BUILD_ROOT="$PROJECT_DIR/build"
+DEFAULT_OUTPUT_ROOT="$BUILD_ROOT/BCP-rendered-assets"
+OUTPUT_ROOT=${DEFAULT_OUTPUT_ROOT:A}
+PREVIEW_ROOT="$BUILD_ROOT/BCP-audition"
+STAGE_DIR=
+MASTER_FILE="$STAGE_DIR/bcp-master.wav"
+RAW_MONO_FILE="$STAGE_DIR/source-mono.wav"
+TARGET_ROOT="$STAGE_DIR/bcp"
+PREVIEW_STAGE_ROOT="$STAGE_DIR/BCP-audition"
+SILENCE_FILE="$STAGE_DIR/silence-180ms.wav"
+OUTPUT_BACKUP_ROOT="$STAGE_DIR/output-backup"
+PREVIEW_BACKUP_ROOT="$STAGE_DIR/preview-backup"
+TEST_FAIL_AT=${SIMUBOARD_BCP_RENDER_TEST_FAIL_AT:-}
+TRANSACTION_COMMITTED=0
+OUTPUT_ORIGINAL_PRESENT=0
+OUTPUT_ORIGINAL_MOVED=0
+OUTPUT_NEW_INSTALLED=0
+PREVIEW_ORIGINAL_PRESENT=0
+PREVIEW_ORIGINAL_MOVED=0
+PREVIEW_NEW_INSTALLED=0
+MASTER_FILTER='pan=mono|c0=0.5*c0+0.5*c1,volume=-3dB,highpass=f=55,afftdn=nr=6:nf=-51:tn=1:ad=0.25:fo=1:gs=1,atrim=start=0.025,asetpts=PTS-STARTPTS'
+RAW_MONO_FILTER='pan=mono|c0=0.5*c0+0.5*c1,asetpts=PTS-STARTPTS'
+RESIDUAL_FILTER='pan=mono|c0=0.5*c0+0.5*c1,volume=-3dB,highpass=f=55,afftdn=nr=6:nf=-51:tn=1:ad=0.25:fo=1:gs=1:om=n,atrim=start=95.525:end=102.025,asetpts=PTS-STARTPTS'
+GENERIC_PRESS_FILTER='highpass=f=95'
+GENERIC_RELEASE_FILTER='highpass=f=108'
+
+typeset -a CLIPS=(
+  'press|GENERIC_R0|16.539|16.598|4.0'
+  'release|GENERIC_R0|16.616|16.710|2.0'
+  'press|GENERIC_R1|40.512|40.566|1.0'
+  'release|GENERIC_R1|40.615|40.678|6.5'
+  'press|GENERIC_R2|58.248|58.344|3.5'
+  'release|GENERIC_R2|58.355|58.420|3.0'
+  'press|GENERIC_R3|59.050|59.107|1.0'
+  'release|GENERIC_R3|59.125|59.171|4.5'
+  'press|GENERIC_R4|66.579|66.612|4.5'
+  'release|GENERIC_R4|66.671|66.736|6.5'
+  'press|GENERIC_R0_ALT|20.000|20.077|-4.0'
+  'release|GENERIC_R0_ALT|20.107|20.145|2.0'
+  'press|GENERIC_R1_ALT|39.165|39.231|2.0'
+  'release|GENERIC_R1_ALT|39.261|39.299|-4.7'
+  'press|GENERIC_R2_ALT|43.650|43.727|0.0'
+  'release|GENERIC_R2_ALT|43.761|43.807|-4.9'
+  'press|GENERIC_R3_ALT|49.506|49.596|-0.5'
+  'release|GENERIC_R3_ALT|49.610|49.634|-3.3'
+  'press|GENERIC_R4_ALT|72.798|72.891|-0.5'
+  'release|GENERIC_R4_ALT|72.915|72.961|-4.7'
+  'press|SHIFT|99.524|99.608|0.0'
+  'release|SHIFT|99.659|99.782|0.0'
+  'press|BACKSPACE|97.648|97.714|2.0'
+  'release|BACKSPACE|97.726|97.844|2.0'
+  'press|ENTER|98.663|98.713|2.0'
+  'release|ENTER|98.726|98.846|2.0'
+  'press|SPACE|101.444|101.498|-0.5'
+  'release|SPACE|101.522|101.626|2.0'
+)
+
+typeset -a CYCLES=(
+  'GENERIC_R0|16.539|16.710'
+  'GENERIC_R1|40.512|40.678'
+  'GENERIC_R2|58.248|58.420'
+  'GENERIC_R3|59.050|59.171'
+  'GENERIC_R4|66.579|66.736'
+  'GENERIC_R0_ALT|20.000|20.145'
+  'GENERIC_R1_ALT|39.165|39.299'
+  'GENERIC_R2_ALT|43.650|43.807'
+  'GENERIC_R3_ALT|49.506|49.634'
+  'GENERIC_R4_ALT|72.798|72.961'
+  'SHIFT|99.524|99.782'
+  'BACKSPACE|97.648|97.844'
+  'ENTER|98.663|98.846'
+  'SPACE|101.444|101.626'
+)
+
+typeset -a RAPID_SEQUENCE=(
+  GENERIC_R2 GENERIC_R1_ALT GENERIC_R3_ALT GENERIC_R2_ALT GENERIC_R1
+  GENERIC_R0_ALT GENERIC_R2 GENERIC_R3 GENERIC_R1_ALT GENERIC_R2_ALT
+  GENERIC_R1 GENERIC_R2_ALT GENERIC_R3 GENERIC_R2 GENERIC_R0
+  GENERIC_R1_ALT GENERIC_R3_ALT GENERIC_R2_ALT GENERIC_R1 GENERIC_R4_ALT
+)
+
+for command_name in ffmpeg ffprobe shasum; do
+  if ! command -v "$command_name" >/dev/null 2>&1; then
+    print -u2 "Missing required command: $command_name"
+    exit 69
+  fi
+done
+
+STAT_BIN=/usr/bin/stat
+if [[ ! -x "$STAT_BIN" ]]; then
+  STAT_BIN=$(command -v stat || true)
+fi
+if [[ -z "$STAT_BIN" ]]; then
+  print -u2 "Missing required command: stat"
+  exit 69
+fi
+
+if [[ -L "$BUILD_ROOT" ]]; then
+  print -u2 "Build root must not be a symlink: $BUILD_ROOT"
+  exit 65
+fi
+if [[ -e "$BUILD_ROOT" && ! -d "$BUILD_ROOT" ]]; then
+  print -u2 "Build root is not a directory: $BUILD_ROOT"
+  exit 65
+fi
+mkdir -p "$BUILD_ROOT"
+STAGE_DIR=$(mktemp -d "$BUILD_ROOT/.bcp-render-staging.XXXXXX")
+MASTER_FILE="$STAGE_DIR/bcp-master.wav"
+RAW_MONO_FILE="$STAGE_DIR/source-mono.wav"
+TARGET_ROOT="$STAGE_DIR/bcp"
+PREVIEW_STAGE_ROOT="$STAGE_DIR/BCP-audition"
+SILENCE_FILE="$STAGE_DIR/silence-180ms.wav"
+OUTPUT_BACKUP_ROOT="$STAGE_DIR/output-backup"
+PREVIEW_BACKUP_ROOT="$STAGE_DIR/preview-backup"
+
+is_fixed_target_directory() {
+  local path=$1
+
+  [[ "$path" == "$OUTPUT_ROOT" || "$path" == "$PREVIEW_ROOT" ]]
+}
+
+validate_fixed_target_directory() {
+  local path=$1
+
+  if ! is_fixed_target_directory "$path"; then
+    print -u2 "Refusing unexpected target directory: $path"
+    exit 65
+  fi
+  if [[ -L "$path" ]]; then
+    print -u2 "Target path must not be a symlink: $path"
+    exit 65
+  fi
+  if [[ -e "$path" && ! -d "$path" ]]; then
+    print -u2 "Target path is not a directory: $path"
+    exit 65
+  fi
+}
+
+maybe_inject_failure() {
+  local point=$1
+
+  if [[ -n "$TEST_FAIL_AT" && "$TEST_FAIL_AT" == "$point" ]]; then
+    print -u2 "Injected transactional test failure at: $point"
+    exit 70
+  fi
+}
+
+rollback_target() {
+  local final_root=$1
+  local backup_root=$2
+  local original_present=$3
+  local original_moved=$4
+  local new_installed=$5
+
+  if ! is_fixed_target_directory "$final_root"; then
+    return
+  fi
+
+  if (( original_moved )); then
+    [[ -e "$final_root" || -L "$final_root" ]] && rm -rf "$final_root"
+    if [[ -e "$backup_root" || -L "$backup_root" ]]; then
+      mv "$backup_root" "$final_root"
+    fi
+  elif (( ! original_present && new_installed )); then
+    [[ -e "$final_root" || -L "$final_root" ]] && rm -rf "$final_root"
+  fi
+}
+
+cleanup() {
+  if (( ! TRANSACTION_COMMITTED )); then
+    rollback_target \
+      "$PREVIEW_ROOT" \
+      "$PREVIEW_BACKUP_ROOT" \
+      "$PREVIEW_ORIGINAL_PRESENT" \
+      "$PREVIEW_ORIGINAL_MOVED" \
+      "$PREVIEW_NEW_INSTALLED"
+    rollback_target \
+      "$OUTPUT_ROOT" \
+      "$OUTPUT_BACKUP_ROOT" \
+      "$OUTPUT_ORIGINAL_PRESENT" \
+      "$OUTPUT_ORIGINAL_MOVED" \
+      "$OUTPUT_NEW_INSTALLED"
+  fi
+  rm -rf "$STAGE_DIR"
+}
+trap cleanup EXIT
+
+if [[ ! -f "$SOURCE_VIDEO" || ! -r "$SOURCE_VIDEO" ]]; then
+  print -u2 "Missing or unreadable source video: $SOURCE_VIDEO"
+  exit 66
+fi
+
+file_mtime() {
+  local path=$1
+
+  if "$STAT_BIN" -f '%m' "$path" >/dev/null 2>&1; then
+    "$STAT_BIN" -f '%m' "$path"
+  else
+    "$STAT_BIN" -c '%Y' "$path"
+  fi
+}
+
+sha256_of() {
+  local checksum
+
+  checksum=$(shasum -a 256 "$1")
+  print -- "${checksum%% *}"
+}
+
+verify_source_unchanged() {
+  local current_sha current_mtime
+
+  current_sha=$(sha256_of "$SOURCE_VIDEO")
+  current_mtime=$(file_mtime "$SOURCE_VIDEO")
+
+  if [[ "$TEST_FAIL_AT" == final-verify && $OUTPUT_NEW_INSTALLED -eq 1 && $PREVIEW_NEW_INSTALLED -eq 1 ]]; then
+    print -u2 "Injected transactional test failure at: final-verify"
+    exit 70
+  fi
+
+  if [[ "$current_sha" != "$SOURCE_SHA_BEFORE" || "$current_mtime" != "$SOURCE_MTIME_BEFORE" ]]; then
+    print -u2 "Source changed during render:"
+    print -u2 "  before sha256=$SOURCE_SHA_BEFORE mtime=$SOURCE_MTIME_BEFORE"
+    print -u2 "  after  sha256=$current_sha mtime=$current_mtime"
+    exit 65
+  fi
+}
+
+format_seconds() {
+  printf '%.6f' "$1"
+}
+
+timestamp_to_samples() {
+  local timestamp=$1
+  local milliseconds=${timestamp//./}
+
+  print -- $(( 10#$milliseconds * 48 ))
+}
+
+render_master() {
+  ffmpeg \
+    -hide_banner \
+    -loglevel error \
+    -nostdin \
+    -y \
+    -i "$SOURCE_VIDEO" \
+    -vn \
+    -af "$MASTER_FILTER" \
+    -ac 1 \
+    -ar 48000 \
+    -c:a pcm_f32le \
+    -map_metadata -1 \
+    "$MASTER_FILE"
+}
+
+render_raw_mono_source() {
+  ffmpeg \
+    -hide_banner \
+    -loglevel error \
+    -nostdin \
+    -y \
+    -i "$SOURCE_VIDEO" \
+    -vn \
+    -af "$RAW_MONO_FILTER" \
+    -ac 1 \
+    -ar 48000 \
+    -c:a pcm_s16le \
+    -map_metadata -1 \
+    "$RAW_MONO_FILE"
+}
+
+render_segment() {
+  local phase=$1
+  local sample_name=$2
+  local start_seconds=$3
+  local end_seconds=$4
+  local -F 6 gain_db=$5
+  local -i start_sample=0
+  local -i end_sample=0
+  local -i sample_count=0
+  local -i fade_in_samples=0
+  local -i fade_out_samples=0
+  local -i fade_out_start_sample=0
+  local target_file="$TARGET_ROOT/$phase/$sample_name.wav"
+  local filter_chain
+
+  start_sample=$(timestamp_to_samples "$start_seconds")
+  end_sample=$(timestamp_to_samples "$end_seconds")
+  (( sample_count = end_sample - start_sample ))
+  if (( sample_count <= 0 )); then
+    print -u2 "Invalid clip duration for $phase/$sample_name"
+    exit 65
+  fi
+
+  if [[ "$phase" == press ]]; then
+    (( fade_out_samples = sample_count < 192 ? sample_count : 192 ))
+  else
+    if [[ "$sample_name" == GENERIC_* ]]; then
+      (( fade_in_samples = sample_count < 48 ? sample_count : 48 ))
+    else
+      (( fade_in_samples = sample_count < 96 ? sample_count : 96 ))
+    fi
+    (( fade_out_samples = sample_count < 192 ? sample_count : 192 ))
+  fi
+  (( fade_out_start_sample = sample_count - fade_out_samples ))
+
+  filter_chain="atrim=start_sample=${start_sample}:end_sample=${end_sample},asetpts=PTS-STARTPTS,volume=$(printf '%.1f' "$gain_db")dB"
+  if [[ "$sample_name" == GENERIC_* ]]; then
+    if [[ "$phase" == press ]]; then
+      filter_chain+=",$GENERIC_PRESS_FILTER"
+    else
+      filter_chain+=",$GENERIC_RELEASE_FILTER"
+    fi
+  fi
+  if [[ "$phase" == release ]]; then
+    filter_chain+=",afade=t=in:ss=0:ns=${fade_in_samples}"
+  fi
+  filter_chain+=",afade=t=out:ss=${fade_out_start_sample}:ns=${fade_out_samples},atrim=end_sample=$(( sample_count - 1 )),apad=pad_len=1"
+
+  mkdir -p "${target_file:h}"
+  ffmpeg \
+    -hide_banner \
+    -loglevel error \
+    -nostdin \
+    -y \
+    -i "$MASTER_FILE" \
+    -af "$filter_chain" \
+    -ac 1 \
+    -ar 48000 \
+    -c:a pcm_s16le \
+    -map_metadata -1 \
+    "$target_file"
+}
+
+render_residual_preview() {
+  mkdir -p "$PREVIEW_STAGE_ROOT"
+  ffmpeg \
+    -hide_banner \
+    -loglevel error \
+    -nostdin \
+    -y \
+    -i "$SOURCE_VIDEO" \
+    -vn \
+    -af "$RESIDUAL_FILTER" \
+    -ac 1 \
+    -ar 48000 \
+    -c:a pcm_s16le \
+    -map_metadata -1 \
+    "$PREVIEW_STAGE_ROOT/BCP-denoise-residual.wav"
+}
+
+render_raw_preview_cycle() {
+  local sample_name=$1
+  local start_seconds=$2
+  local end_seconds=$3
+  local -i start_sample=0
+  local -i end_sample=0
+  local target_file="$STAGE_DIR/raw-cycle-$sample_name.wav"
+
+  start_sample=$(timestamp_to_samples "$start_seconds")
+  end_sample=$(timestamp_to_samples "$end_seconds")
+
+  ffmpeg \
+    -hide_banner \
+    -loglevel error \
+    -nostdin \
+    -y \
+    -i "$RAW_MONO_FILE" \
+    -af "atrim=start_sample=${start_sample}:end_sample=${end_sample},asetpts=PTS-STARTPTS" \
+    -ac 1 \
+    -ar 48000 \
+    -c:a pcm_s16le \
+    -map_metadata -1 \
+    "$target_file"
+}
+
+render_processed_preview_cycle() {
+  local sample_name=$1
+  local target_file="$STAGE_DIR/processed-cycle-$sample_name.wav"
+
+  ffmpeg \
+    -hide_banner \
+    -loglevel error \
+    -nostdin \
+    -y \
+    -i "$TARGET_ROOT/press/$sample_name.wav" \
+    -i "$TARGET_ROOT/release/$sample_name.wav" \
+    -filter_complex '[0:a][1:a]concat=n=2:v=0:a=1' \
+    -ac 1 \
+    -ar 48000 \
+    -c:a pcm_s16le \
+    -map_metadata -1 \
+    "$target_file"
+}
+
+render_rapid_typing_preview() {
+  local -a input_args=()
+  local filter_complex=""
+  local mix_inputs=""
+  local sample_name
+  local -i event_index=0
+  local -i input_index=0
+  local -i press_delay_samples=0
+  local -i release_delay_samples=0
+
+  for sample_name in "${RAPID_SEQUENCE[@]}"; do
+    press_delay_samples=$(( event_index * 4000 ))
+    release_delay_samples=$(( press_delay_samples + 2496 ))
+
+    input_args+=(-i "$TARGET_ROOT/press/$sample_name.wav")
+    if [[ -n "$filter_complex" ]]; then
+      filter_complex+=";"
+    fi
+    filter_complex+="[${input_index}:a]adelay=${press_delay_samples}S:all=1[p${event_index}]"
+    mix_inputs+="[p${event_index}]"
+    (( input_index += 1 ))
+
+    input_args+=(-i "$TARGET_ROOT/release/$sample_name.wav")
+    filter_complex+=";[${input_index}:a]adelay=${release_delay_samples}S:all=1[r${event_index}]"
+    mix_inputs+="[r${event_index}]"
+    (( input_index += 1 ))
+    (( event_index += 1 ))
+  done
+
+  filter_complex+=";${mix_inputs}amix=inputs=${input_index}:normalize=0:dropout_transition=0,volume=0.8[out]"
+
+  ffmpeg \
+    -hide_banner \
+    -loglevel error \
+    -nostdin \
+    -y \
+    "${input_args[@]}" \
+    -filter_complex "$filter_complex" \
+    -map '[out]' \
+    -ac 1 \
+    -ar 48000 \
+    -c:a pcm_s16le \
+    -map_metadata -1 \
+    "$PREVIEW_STAGE_ROOT/BCP-rapid-typing-preview.wav"
+}
+
+render_silence_bridge() {
+  ffmpeg \
+    -hide_banner \
+    -loglevel error \
+    -nostdin \
+    -y \
+    -f lavfi \
+    -i 'anullsrc=channel_layout=mono:sample_rate=48000' \
+    -t 0.180 \
+    -c:a pcm_s16le \
+    -map_metadata -1 \
+    "$SILENCE_FILE"
+}
+
+concat_segments() {
+  local target_file=$1
+  local include_silence=$2
+  shift 2
+  local list_file="$STAGE_DIR/${target_file:t:r}.ffconcat"
+  local segment_file
+  local segment_count=$#
+  local index=1
+
+  {
+    print 'ffconcat version 1.0'
+    for segment_file in "$@"; do
+      print "file '$segment_file'"
+      if [[ "$include_silence" == yes && $index -lt $segment_count ]]; then
+        print "file '$SILENCE_FILE'"
+      fi
+      (( index++ ))
+    done
+  } > "$list_file"
+
+  ffmpeg \
+    -hide_banner \
+    -loglevel error \
+    -nostdin \
+    -y \
+    -f concat \
+    -safe 0 \
+    -i "$list_file" \
+    -ac 1 \
+    -ar 48000 \
+    -c:a pcm_s16le \
+    -map_metadata -1 \
+    "$target_file"
+}
+
+concat_plain() {
+  concat_segments "$1" no "${@:2}"
+}
+
+concat_with_silence() {
+  concat_segments "$1" yes "${@:2}"
+}
+
+install_output_root() {
+  validate_fixed_target_directory "$OUTPUT_ROOT"
+  mkdir -p "${OUTPUT_ROOT:h}"
+
+  if [[ -e "$OUTPUT_ROOT" ]]; then
+    OUTPUT_ORIGINAL_PRESENT=1
+    mv "$OUTPUT_ROOT" "$OUTPUT_BACKUP_ROOT"
+    OUTPUT_ORIGINAL_MOVED=1
+  fi
+
+  mv "$TARGET_ROOT" "$OUTPUT_ROOT"
+  OUTPUT_NEW_INSTALLED=1
+  maybe_inject_failure after-output-install
+}
+
+install_preview_root() {
+  validate_fixed_target_directory "$PREVIEW_ROOT"
+  mkdir -p "${PREVIEW_ROOT:h}"
+
+  if [[ -e "$PREVIEW_ROOT" ]]; then
+    PREVIEW_ORIGINAL_PRESENT=1
+    mv "$PREVIEW_ROOT" "$PREVIEW_BACKUP_ROOT"
+    PREVIEW_ORIGINAL_MOVED=1
+  fi
+
+  maybe_inject_failure before-preview-install
+  mv "$PREVIEW_STAGE_ROOT" "$PREVIEW_ROOT"
+  PREVIEW_NEW_INSTALLED=1
+}
+
+validate_rendered_tree() {
+  local root=$1
+  local -a expected_paths=()
+  local -a actual_paths=()
+  local relative_path sample_file codec_name sample_rate channels bits_per_sample duration_seconds
+
+  for sample_name in \
+    GENERIC_R0 GENERIC_R1 GENERIC_R2 GENERIC_R3 GENERIC_R4 \
+    GENERIC_R0_ALT GENERIC_R1_ALT GENERIC_R2_ALT GENERIC_R3_ALT GENERIC_R4_ALT \
+    SHIFT BACKSPACE ENTER SPACE; do
+    expected_paths+=("press/$sample_name.wav")
+    expected_paths+=("release/$sample_name.wav")
+  done
+
+  while IFS= read -r -d '' sample_file; do
+    relative_path=${sample_file#$root/}
+    actual_paths+=("$relative_path")
+  done < <(find "$root" -type f -name '*.wav' -print0 | LC_ALL=C sort -z)
+
+  if [[ "$(printf '%s\n' "${actual_paths[@]}")" != "$(printf '%s\n' "${expected_paths[@]}" | LC_ALL=C sort)" ]]; then
+    print -u2 "Unexpected generated file set under $root"
+    print -u2 "Expected:"
+    printf '%s\n' "${expected_paths[@]}" | LC_ALL=C sort >&2
+    print -u2 "Actual:"
+    printf '%s\n' "${actual_paths[@]}" >&2
+    exit 65
+  fi
+
+  for relative_path in "${actual_paths[@]}"; do
+    sample_file="$root/$relative_path"
+    codec_name=$(ffprobe -v error -select_streams a:0 -show_entries stream=codec_name -of default=noprint_wrappers=1:nokey=1 "$sample_file")
+    sample_rate=$(ffprobe -v error -select_streams a:0 -show_entries stream=sample_rate -of default=noprint_wrappers=1:nokey=1 "$sample_file")
+    channels=$(ffprobe -v error -select_streams a:0 -show_entries stream=channels -of default=noprint_wrappers=1:nokey=1 "$sample_file")
+    bits_per_sample=$(ffprobe -v error -select_streams a:0 -show_entries stream=bits_per_sample -of default=noprint_wrappers=1:nokey=1 "$sample_file")
+    duration_seconds=$(ffprobe -v error -show_entries format=duration -of default=noprint_wrappers=1:nokey=1 "$sample_file")
+    if [[ "$codec_name" != pcm_s16le || "$sample_rate" != 48000 || "$channels" != 1 || "$bits_per_sample" != 16 ]]; then
+      print -u2 "Unexpected output format for $relative_path: $codec_name, $sample_rate Hz, $channels channel(s), $bits_per_sample bits"
+      exit 65
+    fi
+    if ! awk "BEGIN { exit !($duration_seconds > 0) }"; then
+      print -u2 "Generated file has non-positive duration: $relative_path ($duration_seconds)"
+      exit 65
+    fi
+  done
+}
+
+validate_preview_tree() {
+  local preview_root=$1
+  local preview_count
+
+  preview_count=$(find "$preview_root" -type f -name '*.wav' | wc -l | tr -d ' ')
+  if [[ "$preview_count" != 4 ]]; then
+    print -u2 "Unexpected preview artifact count: $preview_count"
+    exit 65
+  fi
+
+  for preview_file in \
+    "$preview_root/BCP-raw-preview.wav" \
+    "$preview_root/BCP-processed-preview.wav" \
+    "$preview_root/BCP-rapid-typing-preview.wav" \
+    "$preview_root/BCP-denoise-residual.wav"; do
+    if [[ ! -f "$preview_file" ]]; then
+      print -u2 "Missing preview artifact: $preview_file"
+      exit 65
+    fi
+    codec_name=$(ffprobe -v error -select_streams a:0 -show_entries stream=codec_name -of default=noprint_wrappers=1:nokey=1 "$preview_file")
+    sample_rate=$(ffprobe -v error -select_streams a:0 -show_entries stream=sample_rate -of default=noprint_wrappers=1:nokey=1 "$preview_file")
+    channels=$(ffprobe -v error -select_streams a:0 -show_entries stream=channels -of default=noprint_wrappers=1:nokey=1 "$preview_file")
+    bits_per_sample=$(ffprobe -v error -select_streams a:0 -show_entries stream=bits_per_sample -of default=noprint_wrappers=1:nokey=1 "$preview_file")
+    if [[ "$codec_name" != pcm_s16le || "$sample_rate" != 48000 || "$channels" != 1 || "$bits_per_sample" != 16 ]]; then
+      print -u2 "Unexpected preview format for $preview_file"
+      exit 65
+    fi
+  done
+}
+
+render_bcp_assets() {
+  local record phase sample_name start_seconds end_seconds gain_db
+
+  for record in "${CLIPS[@]}"; do
+    IFS='|' read -r phase sample_name start_seconds end_seconds gain_db <<< "$record"
+    render_segment "$phase" "$sample_name" "$start_seconds" "$end_seconds" "$gain_db"
+  done
+}
+
+render_previews() {
+  local record sample_name start_seconds end_seconds
+  local -a raw_cycle_files=()
+  local -a processed_cycle_files=()
+
+  mkdir -p "$PREVIEW_STAGE_ROOT"
+  render_silence_bridge
+
+  for record in "${CYCLES[@]}"; do
+    IFS='|' read -r sample_name start_seconds end_seconds <<< "$record"
+    render_raw_preview_cycle "$sample_name" "$start_seconds" "$end_seconds"
+    render_processed_preview_cycle "$sample_name"
+    raw_cycle_files+=("$STAGE_DIR/raw-cycle-$sample_name.wav")
+    processed_cycle_files+=("$STAGE_DIR/processed-cycle-$sample_name.wav")
+  done
+
+  concat_plain "$PREVIEW_STAGE_ROOT/BCP-raw-preview.wav" "${raw_cycle_files[@]}"
+  concat_with_silence "$PREVIEW_STAGE_ROOT/BCP-processed-preview.wav" "${processed_cycle_files[@]}"
+  render_rapid_typing_preview
+  render_residual_preview
+}
+
+SOURCE_SHA_BEFORE=$(sha256_of "$SOURCE_VIDEO")
+SOURCE_MTIME_BEFORE=$(file_mtime "$SOURCE_VIDEO")
+
+validate_fixed_target_directory "$OUTPUT_ROOT"
+validate_fixed_target_directory "$PREVIEW_ROOT"
+render_master
+render_raw_mono_source
+render_bcp_assets
+validate_rendered_tree "$TARGET_ROOT"
+render_previews
+validate_preview_tree "$PREVIEW_STAGE_ROOT"
+verify_source_unchanged
+install_output_root
+install_preview_root
+verify_source_unchanged
+TRANSACTION_COMMITTED=1
+
+print "Rendered $(find "$OUTPUT_ROOT" -type f -name '*.wav' | wc -l | tr -d ' ') BCP samples into $OUTPUT_ROOT"
+print "Rendered $(find "$PREVIEW_ROOT" -type f -name '*.wav' | wc -l | tr -d ' ') local preview files into $PREVIEW_ROOT"
+print "Source SHA-256: $SOURCE_SHA_BEFORE"
+print "Source mtime: $SOURCE_MTIME_BEFORE"

--- a/docs/plans/2026-08-24-bcp-sound-profile-design.md
+++ b/docs/plans/2026-08-24-bcp-sound-profile-design.md
@@ -1,62 +1,202 @@
-# BCP (Suit80) Built-in Sound Profile Design
+# BCP (Suit80) Local Custom Sound Pack Design
 
 ## Goal
 
-Add a local built-in `BCP (Suit80)` keyboard profile to Battuta from the supplied Bilibili recording, preserving the recording's thick, woody character while reducing stationary room noise and retaining natural press/release variation.
+Turn the supplied Bilibili recording into a local-only `BCP (Suit80)` custom
+sound pack that can be auditioned and installed on one machine without adding a
+new built-in switch profile, app-bundled resources, or redistributable release
+artifacts.
 
-## Scope
+## Final Architecture
 
-- Add one built-in linear-switch profile with raw identifier `bcp`.
-- Export five matched normal-key press/release pairs as row variants (`GENERIC_R0` through `GENERIC_R4`).
-- Use the explicitly identified sequence at `01:36-01:41` to export dedicated `BACKSPACE`, `ENTER`, and `SPACE` press/release pairs.
-- Treat both Shift strikes in that sequence as normal-key candidates because Battuta maps Shift through the generic row samples rather than a dedicated special-key slot.
-- Keep the source video unchanged.
-- Preserve all existing absolute-volume worktree changes.
+- `scripts/render-local-bcp-profile.sh` renders deterministic local WAV assets
+  into the ignored repo paths `SimuBoardMac/build/BCP-rendered-assets` and
+  `SimuBoardMac/build/BCP-audition`.
+- `scripts/install-local-bcp-sound-pack.sh` validates those WAVs and installs a
+  fixed-UUID custom pack into
+  `~/Library/Application Support/SimuBoard/SoundPacks`.
+- The app discovers the installed pack through the existing custom
+  `SoundPackLibrary`, so it appears in the same picker as built-in sounds with
+  selection ID `custom:15d04652-5265-4ea7-a376-8a7e11ff6813`.
+- No `SwitchProfile.bcp` case is added.
+- No `SimuBoardMac/Resources/Audio/bcp` tree is added.
+- No BCP audio enters the app bundle, public build, DMG, appcast, or release.
 
-The resulting profile contains 16 WAV files: ten generic row files plus six dedicated large-key files.
+## Render Specification
 
-## Source Selection
+The renderer keeps the source video unchanged, stages all output in a temp
+directory, and only swaps the fixed local output roots after validation.
 
-The main typing section runs continuously, so candidate normal keys must be selected as complete, non-overlapping press/release cycles with a visible low-energy valley between the two mechanical events. Selection uses a 4 ms RMS envelope, spectral flux, and manual waveform inspection.
+Exact master filter:
 
-For `01:36-01:41`, video order supplies the semantic labels:
+```text
+pan=mono|c0=0.5*c0+0.5*c1,volume=-3dB,highpass=f=55,afftdn=nr=6:nf=-51:tn=1:ad=0.25:fo=1:gs=1,atrim=start=0.025,asetpts=PTS-STARTPTS
+```
 
-1. Shift: normal-key candidate
-2. Backspace: dedicated `BACKSPACE`
-3. Enter: dedicated `ENTER`
-4. Shift: normal-key candidate
-5. Space presses: dedicated `SPACE`, choosing the cleanest complete cycle
+Raw-preview filter:
 
-The waveform determines press/release boundaries; the video sequence determines the key label.
+```text
+pan=mono|c0=0.5*c0+0.5*c1,asetpts=PTS-STARTPTS
+```
 
-## Audio Processing
+Residual-preview filter:
 
-1. Decode the 48 kHz stereo AAC track and downmix it to mono.
-2. Measure stationary noise from low-energy gaps surrounding the large-key sequence and from other nearby room-tone gaps.
-3. Compare FFmpeg `afftdn` and `anlmdn` at conservative strengths. Select the setting that lowers gap RMS without materially changing transient peak level, spectral centroid, or press/release timing.
-4. Apply a 55 Hz high-pass filter, a small low-mid lift near 180 Hz, a mild upper-mid reduction near 3.2 kHz, and a 12 kHz low-pass filter only when the measured output stays within the established Battuta BCP target range.
-5. Retain about 2 ms of pre-roll, add a 4 ms press tail fade, and add 2 ms/4 ms release head/tail fades.
-6. Preserve relative variation while targeting conservative headroom: roughly -10 to -6 dBFS press peaks and -16 to -11 dBFS release peaks.
-7. Export 48 kHz, mono, 16-bit PCM WAV.
+```text
+pan=mono|c0=0.5*c0+0.5*c1,volume=-3dB,highpass=f=55,afftdn=nr=6:nf=-51:tn=1:ad=0.25:fo=1:gs=1:om=n,atrim=start=95.525:end=102.025,asetpts=PTS-STARTPTS
+```
 
-Noise reduction must not use a hard gate or aggressive compression. If either denoiser audibly or measurably smears the attack, fall back to high-pass/EQ plus conservative trimming.
+Audited cut list:
 
-## Application Integration
+```text
+press|GENERIC_R0|16.539|16.598|4.0
+release|GENERIC_R0|16.616|16.710|2.0
+press|GENERIC_R1|40.512|40.566|1.0
+release|GENERIC_R1|40.615|40.678|6.5
+press|GENERIC_R2|58.248|58.344|3.5
+release|GENERIC_R2|58.355|58.420|3.0
+press|GENERIC_R3|59.050|59.107|1.0
+release|GENERIC_R3|59.125|59.171|4.5
+press|GENERIC_R4|66.579|66.612|4.5
+release|GENERIC_R4|66.671|66.736|6.5
+press|GENERIC_R0_ALT|20.000|20.077|-4.0
+release|GENERIC_R0_ALT|20.107|20.145|2.0
+press|GENERIC_R1_ALT|39.165|39.231|2.0
+release|GENERIC_R1_ALT|39.261|39.299|-4.7
+press|GENERIC_R2_ALT|43.650|43.727|0.0
+release|GENERIC_R2_ALT|43.761|43.807|-4.9
+press|GENERIC_R3_ALT|49.506|49.596|-0.5
+release|GENERIC_R3_ALT|49.610|49.634|-3.3
+press|GENERIC_R4_ALT|72.798|72.891|-0.5
+release|GENERIC_R4_ALT|72.915|72.961|-4.7
+press|SHIFT|99.524|99.608|0.0
+release|SHIFT|99.659|99.782|0.0
+press|BACKSPACE|97.648|97.714|2.0
+release|BACKSPACE|97.726|97.844|2.0
+press|ENTER|98.663|98.713|2.0
+release|ENTER|98.726|98.846|2.0
+press|SPACE|101.444|101.498|-0.5
+release|SPACE|101.522|101.626|2.0
+```
 
-- Add `bcp` to `SwitchProfile` with display name `BCP (Suit80)`, family `线性`, and tone `厚实、木感`.
-- Mark the profile as having dedicated special-key samples and row-specific release samples.
-- Place audio under `SimuBoardMac/SimuBoardMac/Resources/Audio/bcp/press` and `release`.
-- Rely on the existing folder-reference resource copy and `SwitchProfile.allCases` discovery; no audio-engine, menu, library, or Xcode project wiring changes are required.
+Exact fade policy:
+
+- Generic press: apply listed gain, trim by exact sample index, add a light
+  `95 Hz` high-pass to limit stacked desk resonance during rapid typing, fade
+  out over 192 samples (`4 ms`), then pad one zero sample. The R1 cut excludes
+  its late secondary impact.
+- Generic release: apply listed gain and a light `108 Hz` high-pass, fade in
+  over 48 samples (`1 ms`), fade out over 192 samples (`4 ms`), trim to
+  `sample_count - 1`, then pad one zero sample. The R3 base and alternate cuts
+  exclude their late secondary impacts.
+- Dedicated big-key release assets retain the prior 96-sample (`2 ms`) fade-in.
+- All exported files are `48 kHz`, mono, `pcm_s16le`.
+
+The renderer also emits:
+
+- `build/BCP-audition/BCP-raw-preview.wav`
+- `build/BCP-audition/BCP-processed-preview.wav`
+- `build/BCP-audition/BCP-rapid-typing-preview.wav`
+- `build/BCP-audition/BCP-denoise-residual.wav`
+
+## Installed Pack Shape
+
+The installer creates a fixed package
+`15d04652-5265-4ea7-a376-8a7e11ff6813.simuboardpack` with:
+
+- `name`: `BCP (Suit80)`
+- `family`: `线性`
+- `tone`: `厚实、木感`
+- `layoutID`: `mac-ansi-tkl-v1`
+- `baseProfileID`: `holypanda`
+- one attribution entry naming the local source filename and visible uploader
+  `J_Eason001`, with a local-only non-redistribution notice
+
+Manifest assignment policy:
+
+- `press.generic = nil`
+- `release.generic = nil`
+- `press.rows` maps `R0` through `R4` to the five generic press assets
+- `release.rows` maps `R0` through `R4` to the five generic release assets
+- alternate per-key overrides distribute five additional matched press/release
+  recordings across approximately half of each small-key row
+- `press.specials` maps `backspace`, `enter`, and `space` to the dedicated
+  press assets
+- `release.specials` maps `backspace`, `enter`, and `space` to the dedicated
+  release assets
+- `press.keyOverrides` and `release.keyOverrides` retain dedicated Shift assets
+  while also assigning the five alternate small-key pairs
+
+This keeps the BCP pack in the same picker as built-in sounds while remaining a
+custom pack loaded from Application Support.
+
+## Migration And Failure Semantics
+
+Renderer transaction boundary:
+
+- Validate the source hash/mtime before and after rendering.
+- Validate all 28 rendered WAVs and all 4 audition WAVs before installation.
+- Replace `build/BCP-rendered-assets` and `build/BCP-audition` transactionally.
+- Roll back both output roots if a swap or final verification fails.
+
+Installer transaction boundary:
+
+- Refuse to overwrite an existing fixed BCP pack with an invalid manifest.
+- Strictly validate and upgrade both the prior 16-asset BCP pack and the
+  Shift-only 18-asset pack while preserving their creation timestamps.
+- Tolerate regular, non-symlink Finder `.DS_Store` files only at the pack root
+  and `assets/`; continue rejecting every other extra entry.
+- Stage the full `.simuboardpack` under the target library root first.
+- Back up the previous fixed BCP pack before swapping in the new one.
+- Roll back exactly to the previous pack if failure occurs after backup or
+  after install but before commit.
+- Leave unrelated custom packs untouched.
+
+Legacy selection migration:
+
+- If the install target is the default
+  `~/Library/Application Support/SimuBoard/SoundPacks` path, migrate
+  `selectedProfile = "bcp"` to
+  `selectedProfile = "custom:15d04652-5265-4ea7-a376-8a7e11ff6813"`.
+- This also applies when the caller passes the default library root explicitly.
+- Non-default explicit library roots do not rewrite the user's selection.
+
+Timestamp semantics:
+
+- `createdAt` is preserved from the first successful install of this fixed UUID.
+- `modifiedAt` is preserved for byte-identical reinstalls.
+- `modifiedAt` advances to the new install time only when the manifest
+  fingerprint changes.
 
 ## Validation
 
-- Add a resource-integrity test before adding the profile/resources. It must require all 16 filenames and validate the profile flags.
-- Verify every output is 48 kHz mono 16-bit PCM, non-empty, below clipping, and within safe one-shot duration limits.
-- Compare pre/post-denoise gap RMS, transient peaks, spectral centroid, and waveform timing.
-- Run the DIY core harness and the audio-variant harness, reporting pre-existing failures separately from BCP failures.
-- Build with full Xcode if available; otherwise report the local toolchain limitation rather than claiming a successful app build.
-- Produce a short before/after audition file and a profile preview for user review.
+Latest working-tree verification for this design:
 
-## Distribution Boundary
+- `./Tests/run-diy-core-harness.sh` -> `493` assertions
+- `./Tests/run-audio-variant-core-harness.sh` -> blocked by the pre-existing
+  `KeyboardAbsoluteVolumeCompensator` symbol drift on the separate
+  absolute-volume workstream
+- `./Tests/run-typing-stats-core-harness.sh` -> `163` assertions
+- `./Tests/run-update-installer-core-harness.sh` -> `8` assertions
 
-The source is an externally authored Bilibili recording whose redistribution rights are not verified. The profile is for local evaluation only. Do not commit or push the extracted WAV files, and do not include them in a public DMG or release until the recording rightsholder grants redistribution permission.
+Automated coverage:
+
+- The DIY harness covers the local BCP installer contract: manifest validity,
+  picker discovery, legacy selection migration, timestamp behavior, and
+  installer rollback behavior.
+- The typing-stats and update-installer auxiliary harnesses confirm those
+  unaffected paths. The audio-variant harness is tracked separately from BCP.
+
+Renderer coverage against the real source is explicit rather than repo-embedded:
+
+- The repository does not ship the source MP4 fixture.
+- Exact cuts, source hash/mtime integrity, repeatability, and renderer rollback
+  are verified with real-source smoke runs, injected renderer failures, and
+  `ffprobe` validation of the generated WAV inventory.
+
+## Historical Note
+
+This work started as a built-in `SwitchProfile.bcp` proposal. Quality review
+and release-boundary review rejected that direction because the recording is
+local-only and permission to redistribute is unverified. The final design
+therefore pivots to an Application Support custom pack with ignored local render
+artifacts and an installer-managed lifecycle.

--- a/docs/plans/2026-08-24-bcp-sound-profile-design.md
+++ b/docs/plans/2026-08-24-bcp-sound-profile-design.md
@@ -1,0 +1,62 @@
+# BCP (Suit80) Built-in Sound Profile Design
+
+## Goal
+
+Add a local built-in `BCP (Suit80)` keyboard profile to Battuta from the supplied Bilibili recording, preserving the recording's thick, woody character while reducing stationary room noise and retaining natural press/release variation.
+
+## Scope
+
+- Add one built-in linear-switch profile with raw identifier `bcp`.
+- Export five matched normal-key press/release pairs as row variants (`GENERIC_R0` through `GENERIC_R4`).
+- Use the explicitly identified sequence at `01:36-01:41` to export dedicated `BACKSPACE`, `ENTER`, and `SPACE` press/release pairs.
+- Treat both Shift strikes in that sequence as normal-key candidates because Battuta maps Shift through the generic row samples rather than a dedicated special-key slot.
+- Keep the source video unchanged.
+- Preserve all existing absolute-volume worktree changes.
+
+The resulting profile contains 16 WAV files: ten generic row files plus six dedicated large-key files.
+
+## Source Selection
+
+The main typing section runs continuously, so candidate normal keys must be selected as complete, non-overlapping press/release cycles with a visible low-energy valley between the two mechanical events. Selection uses a 4 ms RMS envelope, spectral flux, and manual waveform inspection.
+
+For `01:36-01:41`, video order supplies the semantic labels:
+
+1. Shift: normal-key candidate
+2. Backspace: dedicated `BACKSPACE`
+3. Enter: dedicated `ENTER`
+4. Shift: normal-key candidate
+5. Space presses: dedicated `SPACE`, choosing the cleanest complete cycle
+
+The waveform determines press/release boundaries; the video sequence determines the key label.
+
+## Audio Processing
+
+1. Decode the 48 kHz stereo AAC track and downmix it to mono.
+2. Measure stationary noise from low-energy gaps surrounding the large-key sequence and from other nearby room-tone gaps.
+3. Compare FFmpeg `afftdn` and `anlmdn` at conservative strengths. Select the setting that lowers gap RMS without materially changing transient peak level, spectral centroid, or press/release timing.
+4. Apply a 55 Hz high-pass filter, a small low-mid lift near 180 Hz, a mild upper-mid reduction near 3.2 kHz, and a 12 kHz low-pass filter only when the measured output stays within the established Battuta BCP target range.
+5. Retain about 2 ms of pre-roll, add a 4 ms press tail fade, and add 2 ms/4 ms release head/tail fades.
+6. Preserve relative variation while targeting conservative headroom: roughly -10 to -6 dBFS press peaks and -16 to -11 dBFS release peaks.
+7. Export 48 kHz, mono, 16-bit PCM WAV.
+
+Noise reduction must not use a hard gate or aggressive compression. If either denoiser audibly or measurably smears the attack, fall back to high-pass/EQ plus conservative trimming.
+
+## Application Integration
+
+- Add `bcp` to `SwitchProfile` with display name `BCP (Suit80)`, family `线性`, and tone `厚实、木感`.
+- Mark the profile as having dedicated special-key samples and row-specific release samples.
+- Place audio under `SimuBoardMac/SimuBoardMac/Resources/Audio/bcp/press` and `release`.
+- Rely on the existing folder-reference resource copy and `SwitchProfile.allCases` discovery; no audio-engine, menu, library, or Xcode project wiring changes are required.
+
+## Validation
+
+- Add a resource-integrity test before adding the profile/resources. It must require all 16 filenames and validate the profile flags.
+- Verify every output is 48 kHz mono 16-bit PCM, non-empty, below clipping, and within safe one-shot duration limits.
+- Compare pre/post-denoise gap RMS, transient peaks, spectral centroid, and waveform timing.
+- Run the DIY core harness and the audio-variant harness, reporting pre-existing failures separately from BCP failures.
+- Build with full Xcode if available; otherwise report the local toolchain limitation rather than claiming a successful app build.
+- Produce a short before/after audition file and a profile preview for user review.
+
+## Distribution Boundary
+
+The source is an externally authored Bilibili recording whose redistribution rights are not verified. The profile is for local evaluation only. Do not commit or push the extracted WAV files, and do not include them in a public DMG or release until the recording rightsholder grants redistribution permission.

--- a/docs/plans/2026-08-24-bcp-sound-profile.md
+++ b/docs/plans/2026-08-24-bcp-sound-profile.md
@@ -1,0 +1,191 @@
+# BCP (Suit80) Local Custom Sound Pack Final Plan
+
+Status: implemented in the current working tree as a local custom-pack workflow, not a built-in
+bundled switch profile.
+
+## Goal
+
+Provide a deterministic local pipeline that:
+
+- renders 28 audited BCP WAV assets plus audition files from the supplied MP4
+- installs them as one fixed custom sound pack in Application Support
+- surfaces that pack in the existing sound picker beside built-in sounds
+- keeps all BCP artifacts out of the app bundle and release outputs
+
+## Delivered Components
+
+- `SimuBoardMac/scripts/render-local-bcp-profile.sh`
+  - fixed source argument
+  - fixed ignored output roots:
+    `SimuBoardMac/build/BCP-rendered-assets` and
+    `SimuBoardMac/build/BCP-audition`
+  - transactional replacement of both local output roots
+  - source hash/mtime verification before and after install
+- `SimuBoardMac/scripts/install-local-bcp-sound-pack.sh`
+  - validates exactly 28 rendered WAV files
+  - installs fixed UUID
+    `15d04652-5265-4ea7-a376-8a7e11ff6813.simuboardpack`
+    into `~/Library/Application Support/SimuBoard/SoundPacks`
+  - emits a manifest with row/special press/release assignments and one
+    attribution record
+  - migrates legacy built-in `bcp` selection to the custom selection ID when
+    the install target is the default library root
+- `SimuBoardMac/Tests/DIYCoreHarness.swift`
+  - defines the local BCP installer contract, timestamp semantics, picker
+    discovery, and installer rollback behavior
+- `docs/plans/2026-08-24-bcp-sound-profile-design.md`
+  - records the final architecture and local-only release boundary
+
+## Deterministic Render Contract
+
+Master filter:
+
+```text
+pan=mono|c0=0.5*c0+0.5*c1,volume=-3dB,highpass=f=55,afftdn=nr=6:nf=-51:tn=1:ad=0.25:fo=1:gs=1,atrim=start=0.025,asetpts=PTS-STARTPTS
+```
+
+Audited cut list:
+
+```text
+press|GENERIC_R0|16.539|16.598|4.0
+release|GENERIC_R0|16.616|16.710|2.0
+press|GENERIC_R1|40.512|40.566|1.0
+release|GENERIC_R1|40.615|40.678|6.5
+press|GENERIC_R2|58.248|58.344|3.5
+release|GENERIC_R2|58.355|58.420|3.0
+press|GENERIC_R3|59.050|59.107|1.0
+release|GENERIC_R3|59.125|59.171|4.5
+press|GENERIC_R4|66.579|66.612|4.5
+release|GENERIC_R4|66.671|66.736|6.5
+press|GENERIC_R0_ALT|20.000|20.077|-4.0
+release|GENERIC_R0_ALT|20.107|20.145|2.0
+press|GENERIC_R1_ALT|39.165|39.231|2.0
+release|GENERIC_R1_ALT|39.261|39.299|-4.7
+press|GENERIC_R2_ALT|43.650|43.727|0.0
+release|GENERIC_R2_ALT|43.761|43.807|-4.9
+press|GENERIC_R3_ALT|49.506|49.596|-0.5
+release|GENERIC_R3_ALT|49.610|49.634|-3.3
+press|GENERIC_R4_ALT|72.798|72.891|-0.5
+release|GENERIC_R4_ALT|72.915|72.961|-4.7
+press|SHIFT|99.524|99.608|0.0
+release|SHIFT|99.659|99.782|0.0
+press|BACKSPACE|97.648|97.714|2.0
+release|BACKSPACE|97.726|97.844|2.0
+press|ENTER|98.663|98.713|2.0
+release|ENTER|98.726|98.846|2.0
+press|SPACE|101.444|101.498|-0.5
+release|SPACE|101.522|101.626|2.0
+```
+
+Fade and export rules:
+
+- Generic press clips: exact-sample trim, listed gain, light `95 Hz` high-pass
+  to limit stacked desk resonance during rapid typing, `4 ms` fade-out, and
+  one zero sample pad; the R1 cut ends before its late secondary impact
+- Generic release clips: exact-sample trim at the independent release transient,
+  listed gain, light `108 Hz` high-pass, `1 ms` fade-in, `4 ms` fade-out, and
+  one zero sample pad; the R3 base and alternate cuts end before their late
+  secondary impacts
+- Dedicated big-key release clips retain their prior `2 ms` fade-in and
+  otherwise unchanged processing
+- Every output: `48 kHz` mono `pcm_s16le`
+- Audition outputs:
+  `BCP-raw-preview.wav`, `BCP-processed-preview.wav`,
+  `BCP-rapid-typing-preview.wav`, `BCP-denoise-residual.wav`
+
+## Installed Pack Contract
+
+Installed pack manifest:
+
+- `id`: `15d04652-5265-4ea7-a376-8a7e11ff6813`
+- `name`: `BCP (Suit80)`
+- `family`: `线性`
+- `tone`: `厚实、木感`
+- `layoutID`: `mac-ansi-tkl-v1`
+- `baseProfileID`: `holypanda`
+- `press.generic = nil`, `release.generic = nil`
+- `press.rows` and `release.rows` cover `R0` through `R4`
+- `press.specials` and `release.specials` cover `backspace`, `enter`, `space`
+- `press.keyOverrides` and `release.keyOverrides` map both Shift keys to their
+  dedicated phase assets and alternate approximately half of each small-key row
+  onto the five additional real-recording pairs
+
+Picker integration:
+
+- The pack is discovered from `SoundPackLibrary` as a custom descriptor.
+- It appears in the same picker as built-in sounds.
+- No `SwitchProfile.bcp` is introduced.
+
+## Transaction And Migration Rules
+
+Renderer:
+
+- stage all files under `mktemp`
+- validate output inventory and encoding before swap
+- replace `build/BCP-rendered-assets` and `build/BCP-audition` atomically
+- roll back both roots on any injected or real failure before commit
+
+Installer:
+
+- reject invalid pre-existing fixed BCP manifests
+- upgrade both the prior valid 16-asset pack and the Shift-only 18-asset pack to
+  the 28-asset alternate-small-key shape
+- tolerate ordinary non-symlink `.DS_Store` files at the pack root and
+  `assets/`, while rejecting other extra entries
+- back up the previous fixed BCP pack before publish
+- restore the exact previous pack on failure after backup or after install
+- remove partial first installs if publish fails without an older pack
+- preserve unrelated packs
+
+Selection migration:
+
+- rewrite `selectedProfile = "bcp"` to
+  `custom:15d04652-5265-4ea7-a376-8a7e11ff6813`
+  only when the install target is the default Application Support library root,
+  including explicit use of that default path
+- do not rewrite selection for non-default explicit library roots
+
+Timestamp rules:
+
+- preserve `createdAt` across reinstalls of the fixed UUID
+- preserve `modifiedAt` for byte-stable reinstalls
+- update `modifiedAt` only when the manifest fingerprint changes
+
+## Verification
+
+Current final verification in the working tree:
+
+- `./Tests/run-diy-core-harness.sh` passed with `493` assertions
+- `./Tests/run-audio-variant-core-harness.sh` remains blocked by the
+  pre-existing `KeyboardAbsoluteVolumeCompensator` symbol drift on the separate
+  absolute-volume workstream
+- `./Tests/run-typing-stats-core-harness.sh` passed with `163` assertions
+- `./Tests/run-update-installer-core-harness.sh` passed with `8` assertions
+
+Automated verification scope:
+
+- The DIY harness exercises the installer contract only: manifest shape,
+  library discovery, legacy `bcp` selection migration, timestamp semantics, and
+  installer rollback/failure handling.
+- The repository does not include the source MP4 fixture, so renderer exact
+  cuts are not asserted by an automated harness.
+
+Real-source smoke verification scope:
+
+- Renderer exact cuts, source hash/mtime integrity, repeatability, and renderer
+  rollback are validated separately with explicit runs against the real source,
+  injected renderer failures, and `ffprobe` checks on the generated WAV tree.
+
+## Non-Goals
+
+- Do not add `SwitchProfile.bcp`.
+- Do not add `SimuBoardMac/Resources/Audio/bcp`.
+- Do not ship BCP assets in the bundle, DMG, appcast, release, or public repo.
+- Do not treat the BCP recording as a licensed bundled source.
+
+## Historical Decision Note
+
+The original built-in-profile plan is obsolete. After quality and release
+review, the implementation pivoted to a local custom sound pack because the
+recording is only cleared for local evaluation and must not become a shipped
+bundled asset.


### PR DESCRIPTION
## Summary
- Add a deterministic local renderer and installer for the approved BCP (Suit80) recording.
- Produce a 28-asset custom pack with alternate small-key samples and dedicated Shift, Backspace, Enter, and Space samples.
- Reduce cumulative desk resonance during rapid typing while preserving the large-key recordings.
- Keep source and rendered audio out of the repository, app bundle, and public release artifacts.

## Verification
- `zsh SimuBoardMac/Tests/run-diy-core-harness.sh` — 471 assertions passed in a clean worktree.
- `zsh -n SimuBoardMac/scripts/render-local-bcp-profile.sh`
- `zsh -n SimuBoardMac/scripts/install-local-bcp-sound-pack.sh`
- `git diff --check HEAD^..HEAD`