### PR TITLE
fix: bundle BCP sound pack in Windows releases

### DIFF
--- a/BattutaWindows/README.md
+++ b/BattutaWindows/README.md
@@ -1,6 +1,6 @@
 # Battuta for Windows
 
-原生 Windows 10/11 键盘与鼠标音效应用。Windows 版本以现有 macOS SwiftUI 界面、行为和 237 个音频资源为事实来源，在 `BattutaWindows/` 中独立实现，不修改 `SimuBoardMac/`。
+原生 Windows 10/11 键盘与鼠标音效应用。Windows 版本以现有 macOS SwiftUI 界面、行为和 `237` 个基础内置音频资源加 `1` 个只读 bundled `.simuboardpack`（BCP (Suit80)，含 `28` 个 WAV）为事实来源，在 `BattutaWindows/` 中独立实现，不修改 `SimuBoardMac/`。
 
 ## 开发环境
 
@@ -37,7 +37,7 @@ Windows 代码分为：
 
 - Windows 通知区域面板、深色右键菜单、单实例激活和登录启动。
 - 全局物理键盘与鼠标按下/抬起监听，不做字符转换。
-- 20 种键盘音色、5 种指针音色、独立音量、回弹音和自然变化。
+- 21 种键盘音色、5 种指针音色、独立音量、回弹音和自然变化；其中 BCP (Suit80) 以只读 bundled `.simuboardpack` 发布。
 - 本地 SQLite 输入统计、四种趋势范围、应用时间线、年度对比和逐键热力图。
 - DIY 音色的三种映射模式、音频导入/试听、完整击键拆音、保存启用和安全导入导出。
 - 内置与自定义音色重启恢复；GitHub Release 更新检查。

--- a/BattutaWindows/docs/TESTING_WINDOWS.md
+++ b/BattutaWindows/docs/TESTING_WINDOWS.md
@@ -129,7 +129,7 @@ WPF Dispatcher 消息循环、真实托盘或跨进程 UI Automation 的用例�
 2. 音色解析优先级：逐键、特殊键、R0–R4、generic、内置回退；`inherit`、
    `silent` 和 broken asset。
 3. 四套 gain/rate 均衡轮换、无连续重复；关闭自然变化后只播放原音。
-4. 237 个内置资源、20 个键盘 profile、5 个点击 profile 的目录与解码检查。
+4. 237 个基础内置资源、1 个 bundled BCP `.simuboardpack`（28 个 WAV）、20 个静态键盘 profile、5 个点击 profile 的目录与解码检查。
 5. manifest schema、SHA-256、大小/数量/时长限制和导入导出往返。
 6. ZIP traversal、绝对/UNC/设备路径、ADS、大小写重复项、reparse point、压缩炸弹。
 7. PCM 归一化、64 MiB 解码上限、算术溢出、超时/取消清理和拆音边界。
@@ -204,7 +204,7 @@ Remove-Item Env:\BATTUTA_REQUIRE_INTERACTIVE_TRAY_TEST
 发布目录必须验证：
 
 - PE/RID 为 `win-x64`，版本、产品名与包清单一致。
-- 237 个音频及其哈希完整，包含第三方许可和隐私说明。
+- 237 个基础音频、28 个 bundled BCP WAV 及其哈希完整，包含第三方许可和隐私说明。
 - `NAudio.Wasapi` 与 SQLite native runtime 实际进入发布结果。
 - 不包含 DMG、macOS Sparkle、用户数据库、日志、证书、私钥或临时 fixture。
 - 安装、覆盖升级和卸载不会意外删除设置、统计或 DIY 音色。

--- a/BattutaWindows/scripts/Verify-Msix.ps1
+++ b/BattutaWindows/scripts/Verify-Msix.ps1
@@ -5,6 +5,8 @@ param(
 
     [int]$ExpectedSoundCount = 237,
 
+    [int]$ExpectedBundledPackAssetCount = 28,
+
     [switch]$AllowUnsigned,
 
     [switch]$AllowUntrustedSignature
@@ -76,6 +78,28 @@ try {
         throw "MSIX contains an empty sound asset: $($emptySound.FullName)"
     }
 
+    $bundledPackPrefix = 'BundledSoundPacks/15d04652-5265-4ea7-a376-8a7e11ff6813.simuboardpack/'
+    foreach ($requiredEntry in @(
+        "${bundledPackPrefix}manifest.json",
+        "${bundledPackPrefix}licenses/BCP-Suit80-PERMISSION.txt"
+    )) {
+        if (-not $entries.ContainsKey($requiredEntry)) {
+            throw "MSIX package is missing '$requiredEntry'."
+        }
+    }
+    $bundledAssets = @($archive.Entries | Where-Object {
+        $_.FullName.Replace('\', '/').StartsWith("${bundledPackPrefix}assets/", [System.StringComparison]::Ordinal) -and
+        $_.FullName.EndsWith('.wav', [System.StringComparison]::OrdinalIgnoreCase) -and
+        (-not [string]::IsNullOrEmpty($_.Name))
+    })
+    if ($bundledAssets.Count -ne $ExpectedBundledPackAssetCount) {
+        throw "Expected $ExpectedBundledPackAssetCount bundled BCP assets, found $($bundledAssets.Count)."
+    }
+    $emptyBundledAsset = $bundledAssets | Where-Object Length -LE 0 | Select-Object -First 1
+    if ($null -ne $emptyBundledAsset) {
+        throw "MSIX contains an empty bundled BCP asset: $($emptyBundledAsset.FullName)"
+    }
+
     Add-Type -AssemblyName System.Drawing
     $expectedLogos = @{
         'StoreLogo.png' = @(50, 50)
@@ -115,6 +139,7 @@ try {
         SignatureStatus = $signature.Status
         Signer = if ($null -eq $signature.SignerCertificate) { $null } else { $signature.SignerCertificate.Subject }
         SoundCount = $soundFiles.Count
+        BundledPackAssetCount = $bundledAssets.Count
         TotalFiles = $archive.Entries.Count
     }
 }

--- a/BattutaWindows/scripts/Verify-Portable.ps1
+++ b/BattutaWindows/scripts/Verify-Portable.ps1
@@ -5,6 +5,8 @@ param(
 
     [int]$ExpectedSoundCount = 237,
 
+    [int]$ExpectedBundledPackAssetCount = 28,
+
     [switch]$RequireTrustedSignature
 )
 
@@ -14,6 +16,9 @@ Set-StrictMode -Version Latest
 $publishRoot = (Resolve-Path -LiteralPath $PublishDirectory).Path
 $executable = Join-Path $publishRoot 'Battuta.exe'
 $soundRoot = Join-Path $publishRoot 'Assets\Sounds'
+$bundledPackRoot = Join-Path $publishRoot 'BundledSoundPacks\15d04652-5265-4ea7-a376-8a7e11ff6813.simuboardpack'
+$bundledManifest = Join-Path $bundledPackRoot 'manifest.json'
+$bundledNotice = Join-Path $bundledPackRoot 'licenses\BCP-Suit80-PERMISSION.txt'
 $notices = Join-Path $publishRoot 'THIRD_PARTY_NOTICES.md'
 $license = Join-Path $publishRoot 'LICENSE'
 
@@ -22,6 +27,12 @@ if (-not (Test-Path -LiteralPath $executable -PathType Leaf)) {
 }
 if (-not (Test-Path -LiteralPath $soundRoot -PathType Container)) {
     throw "Portable build is missing Assets\Sounds: $soundRoot"
+}
+if (-not (Test-Path -LiteralPath $bundledManifest -PathType Leaf)) {
+    throw "Portable build is missing bundled BCP manifest: $bundledManifest"
+}
+if (-not (Test-Path -LiteralPath $bundledNotice -PathType Leaf)) {
+    throw "Portable build is missing bundled BCP permission notice: $bundledNotice"
 }
 if (-not (Test-Path -LiteralPath $notices -PathType Leaf)) {
     throw "Portable build is missing THIRD_PARTY_NOTICES.md"
@@ -40,6 +51,16 @@ if ($null -ne $emptySound) {
     throw "Portable build contains an empty sound asset: $($emptySound.FullName)"
 }
 
+$bundledAssets = @(Get-ChildItem -LiteralPath (Join-Path $bundledPackRoot 'assets') -Recurse -File -Filter '*.wav')
+if ($bundledAssets.Count -ne $ExpectedBundledPackAssetCount) {
+    throw "Expected $ExpectedBundledPackAssetCount bundled BCP assets, found $($bundledAssets.Count)."
+}
+
+$emptyBundledAsset = $bundledAssets | Where-Object Length -LE 0 | Select-Object -First 1
+if ($null -ne $emptyBundledAsset) {
+    throw "Portable build contains an empty bundled BCP asset: $($emptyBundledAsset.FullName)"
+}
+
 $executableInfo = [System.Diagnostics.FileVersionInfo]::GetVersionInfo($executable)
 $signature = Get-AuthenticodeSignature -LiteralPath $executable
 if ($RequireTrustedSignature -and
@@ -53,6 +74,7 @@ if ($RequireTrustedSignature -and
     SignatureStatus = $signature.Status
     Signer = if ($null -eq $signature.SignerCertificate) { $null } else { $signature.SignerCertificate.Subject }
     SoundCount = $soundFiles.Count
+    BundledPackAssetCount = $bundledAssets.Count
     TotalBytes = (Get-ChildItem -LiteralPath $publishRoot -Recurse -File |
         Measure-Object -Property Length -Sum).Sum
 }

--- a/BattutaWindows/src/Battuta.Core/SoundPacks/SoundPackModels.cs
+++ b/BattutaWindows/src/Battuta.Core/SoundPacks/SoundPackModels.cs
@@ -280,6 +280,18 @@ public static class SoundPackDescriptors
             IsReadOnly: true,
             CustomPackId: null)).ToArray();
 
+    public static SoundPackDescriptor BundledPack(SoundPackManifest manifest)
+    {
+        ArgumentNullException.ThrowIfNull(manifest);
+        return new SoundPackDescriptor(
+            $"custom:{manifest.Id:D}".ToLowerInvariant(),
+            manifest.Name,
+            manifest.Family ?? "DIY",
+            manifest.Tone ?? "自定义音色",
+            IsReadOnly: true,
+            CustomPackId: manifest.Id);
+    }
+
     public static SoundPackDescriptor Custom(SoundPackManifest manifest)
     {
         ArgumentNullException.ThrowIfNull(manifest);

--- a/BattutaWindows/src/Battuta.Windows/Battuta.Windows.csproj
+++ b/BattutaWindows/src/Battuta.Windows/Battuta.Windows.csproj
@@ -31,6 +31,11 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
     </Content>
+    <Content Include="..\..\..\SimuBoardMac\SimuBoardMac\Resources\BundledSoundPacks\**\*.*">
+      <Link>BundledSoundPacks\%(RecursiveDir)%(Filename)%(Extension)</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+    </Content>
     <Resource Include="..\..\..\SimuBoardMac\Design\AppIconSquare.png">
       <Link>Assets\AppIconSquare.png</Link>
     </Resource>

--- a/BattutaWindows/src/Battuta.Windows/Diy/Packages/DiySoundPackLibrary.cs
+++ b/BattutaWindows/src/Battuta.Windows/Diy/Packages/DiySoundPackLibrary.cs
@@ -9,15 +9,20 @@ public sealed class DiySoundPackLibrary : IDisposable
     private readonly SoundPackValidationLimits _limits;
     private readonly DiySoundPackPackageValidator _packageValidator;
     private readonly IReadOnlyList<SoundPackDescriptor> _builtInDescriptors;
+    private readonly string? _bundledPackRootPath;
     private readonly SemaphoreSlim _gate = new(1, 1);
 
     public DiySoundPackLibrary(
         string? rootPath = null,
         IReadOnlyList<SoundPackDescriptor>? builtInDescriptors = null,
+        string? bundledPackRootPath = null,
         SoundPackValidationLimits? limits = null)
     {
         RootPath = DiySoundPackFileSafety.CanonicalPath(rootPath ?? DefaultRootPath());
         _builtInDescriptors = builtInDescriptors ?? SoundPackDescriptors.BundledDefaults;
+        _bundledPackRootPath = bundledPackRootPath is null
+            ? DefaultBundledPackRootPath()
+            : DiySoundPackFileSafety.CanonicalPath(bundledPackRootPath);
         _limits = limits ?? SoundPackValidationLimits.Standard;
         _packageValidator = new DiySoundPackPackageValidator(_limits);
     }
@@ -181,6 +186,8 @@ public sealed class DiySoundPackLibrary : IDisposable
     private SoundPackDescriptor[] DescriptorsCore(CancellationToken cancellationToken)
     {
         EnsureRoot();
+        var bundled = LoadBundledPacks();
+        var bundledIds = bundled.Keys.ToHashSet();
         var custom = new List<SoundPackDescriptor>();
         foreach (var directory in Directory.EnumerateDirectories(RootPath, "*.simuboardpack"))
         {
@@ -188,6 +195,13 @@ public sealed class DiySoundPackLibrary : IDisposable
             var name = Path.GetFileNameWithoutExtension(directory);
             if (!Guid.TryParse(name, out var id))
             {
+                continue;
+            }
+
+            if (bundledIds.Contains(id))
+            {
+                // Once the app ships the same UUID as a read-only bundled pack,
+                // keep any old local package on disk but hide the duplicate row.
                 continue;
             }
 
@@ -204,12 +218,20 @@ public sealed class DiySoundPackLibrary : IDisposable
 
         custom.Sort((left, right) =>
             StringComparer.CurrentCultureIgnoreCase.Compare(left.Name, right.Name));
-        return _builtInDescriptors.Concat(custom).ToArray();
+        var bundledDescriptors = bundled.Values
+            .Select(document => document.Descriptor)
+            .OrderBy(descriptor => descriptor.Name, StringComparer.CurrentCultureIgnoreCase);
+        return _builtInDescriptors.Concat(bundledDescriptors).Concat(custom).ToArray();
     }
 
     private DiySoundPackDocument LoadCore(Guid id)
     {
         EnsureRoot();
+        if (TryLoadBundledPack(id, out var bundled))
+        {
+            return bundled;
+        }
+
         var path = PackPath(id);
         if (!Directory.Exists(path))
         {
@@ -356,10 +378,62 @@ public sealed class DiySoundPackLibrary : IDisposable
     private void EnsureRoot() =>
         DiySoundPackFileSafety.EnsureSafeDirectory(RootPath, create: true);
 
+    private Dictionary<Guid, DiySoundPackDocument> LoadBundledPacks()
+    {
+        if (string.IsNullOrWhiteSpace(_bundledPackRootPath) ||
+            !Directory.Exists(_bundledPackRootPath))
+        {
+            return [];
+        }
+
+        DiySoundPackFileSafety.EnsureSafeDirectory(_bundledPackRootPath, create: false);
+        var bundled = new Dictionary<Guid, DiySoundPackDocument>();
+        foreach (var directory in Directory.EnumerateDirectories(_bundledPackRootPath, "*.simuboardpack"))
+        {
+            var name = Path.GetFileNameWithoutExtension(directory);
+            if (!Guid.TryParse(name, out var id))
+            {
+                continue;
+            }
+
+            try
+            {
+                var package = _packageValidator.Validate(directory);
+                if (package.Manifest.Id != id)
+                {
+                    continue;
+                }
+
+                bundled[id] = new DiySoundPackDocument(
+                    SoundPackDescriptors.BundledPack(package.Manifest),
+                    package.Manifest,
+                    package.RootPath);
+            }
+            catch (Exception error) when (
+                error is SoundPackException or IOException or UnauthorizedAccessException)
+            {
+                // One damaged bundled package must not hide the remaining
+                // packaged content. Release validation checks the shipped pack.
+            }
+        }
+
+        return bundled;
+    }
+
+    private bool TryLoadBundledPack(Guid id, out DiySoundPackDocument document)
+    {
+        document = null!;
+        var bundled = LoadBundledPacks();
+        return bundled.TryGetValue(id, out document!);
+    }
+
     private static string DefaultRootPath() => Path.Combine(
         Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
         "Battuta",
         "SoundPacks");
+
+    private static string DefaultBundledPackRootPath() =>
+        Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "BundledSoundPacks"));
 
     public void Dispose()
     {

--- a/BattutaWindows/src/Battuta.Windows/Views/Tray/TrayFlyoutWindow.Runtime.cs
+++ b/BattutaWindows/src/Battuta.Windows/Views/Tray/TrayFlyoutWindow.Runtime.cs
@@ -375,12 +375,7 @@ public partial class TrayFlyoutWindow
                 var descriptors = await runtime.SoundPackLibrary
                     .DescriptorsAsync(cancellationToken);
                 cancellationToken.ThrowIfCancellationRequested();
-                var merged = SoundPackDescriptors.BundledDefaults
-                    .Concat(descriptors.Where(descriptor => !descriptor.IsReadOnly))
-                    .GroupBy(descriptor => descriptor.SelectionId, StringComparer.Ordinal)
-                    .Select(group => group.First())
-                    .ToArray();
-                ApplySoundPackChoices(merged);
+                ApplySoundPackChoices(descriptors);
             }
             catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
             {

--- a/BattutaWindows/tests/Battuta.Windows.Tests/Diy/DiySoundPackPackageTests.cs
+++ b/BattutaWindows/tests/Battuta.Windows.Tests/Diy/DiySoundPackPackageTests.cs
@@ -7,6 +7,9 @@ namespace Battuta.Windows.Tests.Diy;
 
 public sealed class DiySoundPackPackageTests
 {
+    private static readonly Guid BundledBcpPackId =
+        Guid.Parse("15d04652-5265-4ea7-a376-8a7e11ff6813");
+
     [Fact]
     public async Task LibraryAndArchiveRoundTripAndApplyCollisionPolicies()
     {
@@ -132,6 +135,53 @@ public sealed class DiySoundPackPackageTests
         Assert.Equal(SoundPackErrorKind.UnsafeFile, rejected.Kind);
     }
 
+    [Fact]
+    public async Task LibraryEnumeratesAndLoadsBundledReadOnlyPack()
+    {
+        using var root = new TemporaryDirectory();
+        using var library = new DiySoundPackLibrary(
+            root.Combine("library"),
+            builtInDescriptors: [],
+            bundledPackRootPath: BundledPackRoot());
+
+        var descriptors = await library.DescriptorsAsync();
+        var descriptor = Assert.Single(descriptors);
+
+        Assert.Equal($"custom:{BundledBcpPackId:D}".ToLowerInvariant(), descriptor.SelectionId);
+        Assert.Equal("BCP (Suit80)", descriptor.Name);
+        Assert.True(descriptor.IsReadOnly);
+        Assert.Equal(BundledBcpPackId, descriptor.CustomPackId);
+
+        var loaded = await library.LoadAsync(BundledBcpPackId);
+        Assert.Equal(BundledBcpPackId, loaded.Manifest.Id);
+        Assert.Equal("BCP (Suit80)", loaded.Manifest.Name);
+        Assert.Equal(28, loaded.Manifest.Assets.Count);
+        Assert.Equal("线性", loaded.Manifest.Family);
+        Assert.Equal("厚实、木感", loaded.Manifest.Tone);
+    }
+
+    [Fact]
+    public async Task BundledPackHidesAndOverridesLocalDuplicateWithSameId()
+    {
+        using var root = new TemporaryDirectory();
+        var localDuplicate = Path.Combine(root.Combine("library"), $"{BundledBcpPackId:D}.simuboardpack");
+        Directory.CreateDirectory(localDuplicate);
+        await File.WriteAllTextAsync(
+            Path.Combine(localDuplicate, "manifest.json"),
+            "{ \"name\": \"broken duplicate\" }");
+        using var library = new DiySoundPackLibrary(
+            root.Combine("library"),
+            builtInDescriptors: [],
+            bundledPackRootPath: BundledPackRoot());
+
+        var descriptors = await library.DescriptorsAsync();
+        Assert.Single(descriptors);
+
+        var loaded = await library.LoadAsync(BundledBcpPackId);
+        Assert.Equal("BCP (Suit80)", loaded.Manifest.Name);
+        Assert.Equal(28, loaded.Manifest.Assets.Count);
+    }
+
     private static SoundPackManifest ManifestFor(PreparedDiyAudio prepared, string name)
     {
         var id = new SoundPackAssetId(prepared.AssetId);
@@ -157,4 +207,11 @@ public sealed class DiySoundPackPackageTests
             },
         };
     }
+
+    private static string BundledPackRoot() => Path.Combine(
+        AudioTestFiles.FindRepositoryRoot(),
+        "SimuBoardMac",
+        "SimuBoardMac",
+        "Resources",
+        "BundledSoundPacks");
 }


### PR DESCRIPTION
## Summary
- package the bundled BCP (Suit80) .simuboardpack into Windows publish outputs
- teach the Windows sound-pack library to enumerate bundled read-only packs and prefer them over duplicate local installs
- update Windows release verification/docs to require the bundled BCP manifest, permission notice, and 28 WAV assets

## Why
The current Battuta 1.1.1 draft Windows ZIP only carries the legacy 237-file Assets/Sounds tree. It does not include BundledSoundPacks, and the Windows runtime did not enumerate bundled read-only .simuboardpack assets, so the draft ZIP cannot truthfully ship BCP (Suit80) as a built-in sound.

## Verification
- static code audit only on this macOS host
- local shell does not provide dotnet or pwsh, so Windows build/test/publish could not be executed here