### PR TITLE
fix: validate Windows BCP release package

### DIFF
--- a/BattutaWindows/scripts/Verify-Portable.ps1
+++ b/BattutaWindows/scripts/Verify-Portable.ps1
@@ -16,7 +16,8 @@ Set-StrictMode -Version Latest
 $publishRoot = (Resolve-Path -LiteralPath $PublishDirectory).Path
 $executable = Join-Path $publishRoot 'Battuta.exe'
 $soundRoot = Join-Path $publishRoot 'Assets\Sounds'
-$bundledPackRoot = Join-Path $publishRoot 'BundledSoundPacks\15d04652-5265-4ea7-a376-8a7e11ff6813.simuboardpack'
+$expectedBundledPackId = '15d04652-5265-4ea7-a376-8a7e11ff6813'
+$bundledPackRoot = Join-Path $publishRoot "BundledSoundPacks\$expectedBundledPackId.simuboardpack"
 $bundledManifest = Join-Path $bundledPackRoot 'manifest.json'
 $bundledNotice = Join-Path $bundledPackRoot 'licenses\BCP-Suit80-PERMISSION.txt'
 $notices = Join-Path $publishRoot 'THIRD_PARTY_NOTICES.md'
@@ -61,18 +62,87 @@ if ($null -ne $emptyBundledAsset) {
     throw "Portable build contains an empty bundled BCP asset: $($emptyBundledAsset.FullName)"
 }
 
+$manifest = Get-Content -LiteralPath $bundledManifest -Raw | ConvertFrom-Json
+if ($manifest.id -ne $expectedBundledPackId) {
+    throw "Bundled BCP manifest has an unexpected id: $($manifest.id)"
+}
+if ($manifest.name -ne 'BCP (Suit80)') {
+    throw "Bundled BCP manifest has an unexpected name: $($manifest.name)"
+}
+
+$manifestAssets = @($manifest.assets.PSObject.Properties)
+if ($manifestAssets.Count -ne $ExpectedBundledPackAssetCount) {
+    throw "Bundled BCP manifest declares $($manifestAssets.Count) assets; expected $ExpectedBundledPackAssetCount."
+}
+foreach ($entry in $manifestAssets) {
+    $asset = $entry.Value
+    if ($entry.Name -ne $asset.id -or $asset.id -ne $asset.sha256) {
+        throw "Bundled BCP asset id/hash mismatch for '$($entry.Name)'."
+    }
+    if ($asset.relativePath -notmatch '^assets/[0-9a-f]{64}\.wav$') {
+        throw "Bundled BCP asset has an unsafe path: $($asset.relativePath)"
+    }
+
+    $relativePath = $asset.relativePath.Replace(
+        '/',
+        [System.IO.Path]::DirectorySeparatorChar)
+    $assetPath = Join-Path $bundledPackRoot $relativePath
+    if (-not (Test-Path -LiteralPath $assetPath -PathType Leaf)) {
+        throw "Bundled BCP manifest references a missing asset: $($asset.relativePath)"
+    }
+
+    $assetInfo = Get-Item -LiteralPath $assetPath
+    if ($assetInfo.Length -ne [long]$asset.byteCount) {
+        throw "Bundled BCP asset has an unexpected byte count: $($asset.relativePath)"
+    }
+    $actualHash = (Get-FileHash -LiteralPath $assetPath -Algorithm SHA256).Hash.ToLowerInvariant()
+    if ($actualHash -ne $asset.sha256) {
+        throw "Bundled BCP asset failed SHA-256 validation: $($asset.relativePath)"
+    }
+}
+
+$permissionAttribution = @($manifest.attributions) | Where-Object {
+    $_.licenseName -eq 'Used with permission' -and
+    $_.notice -match 'Redistribution authorized'
+} | Select-Object -First 1
+if ($null -eq $permissionAttribution) {
+    throw 'Bundled BCP manifest is missing the redistribution permission attribution.'
+}
+$permissionNotice = Get-Content -LiteralPath $bundledNotice -Raw
+if (-not $permissionNotice.Contains('Redistribution of the derived BCP (Suit80) audio assets') -or
+    -not $permissionNotice.Contains('authorized')) {
+    throw 'Bundled BCP permission notice does not record authorized redistribution.'
+}
+
 $executableInfo = [System.Diagnostics.FileVersionInfo]::GetVersionInfo($executable)
-$signature = Get-AuthenticodeSignature -LiteralPath $executable
-if ($RequireTrustedSignature -and
-    ($signature.Status -ne [System.Management.Automation.SignatureStatus]::Valid)) {
-    throw "Battuta.exe must have a trusted signature: $($signature.Status) - $($signature.StatusMessage)"
+$signatureCommand = Get-Command 'Get-AuthenticodeSignature' -ErrorAction SilentlyContinue
+if ($null -eq $signatureCommand) {
+    if ($RequireTrustedSignature) {
+        throw 'Trusted-signature validation requires Windows PowerShell.'
+    }
+    $signatureStatus = 'NotChecked (unsupported on this host)'
+    $signer = $null
+}
+else {
+    $signature = Get-AuthenticodeSignature -LiteralPath $executable
+    if ($RequireTrustedSignature -and
+        ($signature.Status -ne [System.Management.Automation.SignatureStatus]::Valid)) {
+        throw "Battuta.exe must have a trusted signature: $($signature.Status) - $($signature.StatusMessage)"
+    }
+    $signatureStatus = $signature.Status
+    $signer = if ($null -eq $signature.SignerCertificate) {
+        $null
+    }
+    else {
+        $signature.SignerCertificate.Subject
+    }
 }
 [pscustomobject]@{
     Executable = $executable
     ProductVersion = $executableInfo.ProductVersion
     FileVersion = $executableInfo.FileVersion
-    SignatureStatus = $signature.Status
-    Signer = if ($null -eq $signature.SignerCertificate) { $null } else { $signature.SignerCertificate.Subject }
+    SignatureStatus = $signatureStatus
+    Signer = $signer
     SoundCount = $soundFiles.Count
     BundledPackAssetCount = $bundledAssets.Count
     TotalBytes = (Get-ChildItem -LiteralPath $publishRoot -Recurse -File |

--- a/BattutaWindows/tests/Battuta.Windows.Tests/Diy/DiySoundPackPackageTests.cs
+++ b/BattutaWindows/tests/Battuta.Windows.Tests/Diy/DiySoundPackPackageTests.cs
@@ -2,6 +2,7 @@ using System.IO;
 using Battuta.Core.SoundPacks;
 using Battuta.Windows.Diy.Audio;
 using Battuta.Windows.Diy.Packages;
+using Battuta.Windows.Tests.Audio;
 
 namespace Battuta.Windows.Tests.Diy;
 


### PR DESCRIPTION
## Summary
- fix the Windows BCP test compile error introduced in #10
- validate the bundled pack UUID, name, permission attribution, notice, 28 declared assets, byte counts, and SHA-256 hashes
- allow unsigned portable-package verification on non-Windows hosts while keeping trusted-signature checks Windows-only

## Verification
- `dotnet build BattutaWindows/BattutaWindows.sln --configuration Release -p:EnableWindowsTargeting=true`
- `Battuta.Core.Tests`: 121/121 passed
- Windows test assembly compiles; execution remains Windows-only because WPF requires Microsoft.WindowsDesktop.App
- `Publish-Portable.ps1 -Version 1.1.1 -Runtime win-x64`
- extracted ZIP passed `Verify-Portable.ps1`, `unzip -t`, and exact bundled-pack directory comparison
- generated ZIP SHA-256: `4300a60513427a3ac965890f4c0ca6f5a988e71aff8ebc957dc3ef741149f930`