### PR TITLE
test: account for bundled BCP sound pack

### DIFF
--- a/.github/workflows/windows-release.yml
+++ b/.github/workflows/windows-release.yml
@@ -56,7 +56,7 @@ jobs:
         shell: pwsh
         run: >-
           dotnet test --project .\BattutaWindows\tests\Battuta.Windows.Tests\Battuta.Windows.Tests.csproj
-          --configuration Release --no-build --no-restore --minimum-expected-tests 1
+          --configuration Release --no-build --no-restore --minimum-expected-tests 223
           --no-progress --output Normal
 
       - name: Build and verify portable package

--- a/BattutaWindows/tests/Battuta.Windows.Tests/Diy/DiySoundPackPackageTests.cs
+++ b/BattutaWindows/tests/Battuta.Windows.Tests/Diy/DiySoundPackPackageTests.cs
@@ -35,7 +35,10 @@ public sealed class DiySoundPackPackageTests
         Assert.Equal("Round trip", loaded.Manifest.Name);
         Assert.Equal(prepared.AssetId, WaveFixture.Sha256(
             loaded.AssetPath(new SoundPackAssetId(prepared.AssetId))));
-        Assert.Single(await library.DescriptorsAsync());
+        var savedCustomPacks = (await library.DescriptorsAsync())
+            .Where(item => !item.IsReadOnly)
+            .ToArray();
+        Assert.Equal(manifest.Id, Assert.Single(savedCustomPacks).CustomPackId);
 
         _ = await library.SaveAsync(loaded.Manifest with { Name = "Renamed" });
         Assert.Equal("Renamed", (await library.LoadAsync(manifest.Id)).Manifest.Name);
@@ -52,7 +55,9 @@ public sealed class DiySoundPackPackageTests
         Assert.Equal(manifest.Id, first.CustomPackId);
         var duplicated = await archive.ImportAsync(exportedPath, importedLibrary);
         Assert.NotEqual(manifest.Id, duplicated.CustomPackId);
-        Assert.Equal(2, (await importedLibrary.DescriptorsAsync()).Count);
+        Assert.Equal(
+            2,
+            (await importedLibrary.DescriptorsAsync()).Count(item => !item.IsReadOnly));
 
         var collision = await Assert.ThrowsAsync<SoundPackException>(() => archive.ImportAsync(
             exportedPath,


### PR DESCRIPTION
## Summary
- update the DIY archive round-trip test to count editable custom packs instead of assuming the full list excludes bundled read-only packs
- require all 223 Windows/WPF tests in the release workflow

## Evidence
The first native Windows release run built successfully and passed 222/223 tests. The only failure was the stale list-count assertion; the returned collection correctly contained BCP (Suit80) plus the custom fixture.

## Local verification
- full solution build: 0 warnings, 0 errors
- workflow YAML syntax check passed