### PR TITLE
ci: update Windows release actions

### DIFF
--- a/.github/workflows/windows-release.yml
+++ b/.github/workflows/windows-release.yml
@@ -30,10 +30,10 @@ jobs:
 
     steps:
       - name: Check out source
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install .NET SDK
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: 10.0.400
 


### PR DESCRIPTION
## Summary
- update `actions/checkout` and `actions/setup-dotnet` from v4 to v5
- remove the Node.js 20 deprecation annotation observed in the successful Windows 1.1.1 release run

Both official v5 tags were verified from the upstream action repositories. Workflow YAML syntax passes locally.