### PR TITLE
fix: clean packaging staging cross-platform

### DIFF
--- a/BattutaWindows/scripts/Publish-Msix.ps1
+++ b/BattutaWindows/scripts/Publish-Msix.ps1
@@ -51,7 +51,11 @@ if ([string]::IsNullOrWhiteSpace($OutputDirectory)) {
 $outputRoot = [System.IO.Path]::GetFullPath($OutputDirectory)
 $stagingRoot = Join-Path $outputRoot 'staging-msix'
 $stage = Join-Path $stagingRoot ([Guid]::NewGuid().ToString('N'))
-$safeStagingPrefix = [System.IO.Path]::GetFullPath($stagingRoot).TrimEnd('\') + '\'
+$directorySeparators = [char[]]@(
+    [System.IO.Path]::DirectorySeparatorChar,
+    [System.IO.Path]::AltDirectorySeparatorChar)
+$safeStagingPrefix = [System.IO.Path]::GetFullPath($stagingRoot).TrimEnd($directorySeparators) +
+    [System.IO.Path]::DirectorySeparatorChar
 
 Assert-BattutaPackageIdentityName -Name $PackageName
 if ([string]::IsNullOrWhiteSpace($Publisher) -or $Publisher -notmatch '=') {

--- a/BattutaWindows/scripts/Publish-Portable.ps1
+++ b/BattutaWindows/scripts/Publish-Portable.ps1
@@ -31,7 +31,11 @@ if ([string]::IsNullOrWhiteSpace($OutputDirectory)) {
 $outputRoot = [System.IO.Path]::GetFullPath($OutputDirectory)
 $stagingRoot = Join-Path $outputRoot 'staging'
 $stage = Join-Path $stagingRoot ([Guid]::NewGuid().ToString('N'))
-$safeStagingPrefix = [System.IO.Path]::GetFullPath($stagingRoot).TrimEnd('\') + '\'
+$directorySeparators = [char[]]@(
+    [System.IO.Path]::DirectorySeparatorChar,
+    [System.IO.Path]::AltDirectorySeparatorChar)
+$safeStagingPrefix = [System.IO.Path]::GetFullPath($stagingRoot).TrimEnd($directorySeparators) +
+    [System.IO.Path]::DirectorySeparatorChar
 
 New-Item -ItemType Directory -Force -Path $outputRoot | Out-Null
 New-Item -ItemType Directory -Force -Path $stagingRoot | Out-Null


### PR DESCRIPTION
## Summary
- use the host platform directory separator when guarding portable and MSIX staging cleanup
- prevent successful macOS cross-target packaging from leaking the full 205 MB publish directory

## Verification
- PowerShell parser passed for both scripts
- a full macOS-to-win-x64 portable package build and strengthened BCP validation passed
- the per-run staging directory was removed after packaging