### PR TITLE
fix(windows): restore clean 1.1.2 build

### DIFF
--- a/BattutaWindows/src/Battuta.Windows/Battuta.Windows.csproj
+++ b/BattutaWindows/src/Battuta.Windows/Battuta.Windows.csproj
@@ -4,6 +4,10 @@
     <ProjectReference Include="..\Battuta.Core\Battuta.Core.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <InternalsVisibleTo Include="Battuta.Windows.Tests" />
+  </ItemGroup>
+
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
     <TargetFramework>net10.0-windows10.0.19041.0</TargetFramework>

--- a/BattutaWindows/src/Battuta.Windows/Stats/Visualization/AdaptiveHeatScale.cs
+++ b/BattutaWindows/src/Battuta.Windows/Stats/Visualization/AdaptiveHeatScale.cs
@@ -67,9 +67,9 @@ public readonly record struct AdaptiveHeatScale(double Low, double High)
         return Math.Clamp(Math.Abs(value) / High, 0, 1);
     }
 
-    private static double Percentile(IReadOnlyList<double> sorted, double fraction)
+    private static double Percentile(double[] sorted, double fraction)
     {
-        var position = Math.Clamp(fraction, 0, 1) * (sorted.Count - 1);
+        var position = Math.Clamp(fraction, 0, 1) * (sorted.Length - 1);
         var lowerIndex = (int)Math.Floor(position);
         var upperIndex = (int)Math.Ceiling(position);
         if (lowerIndex == upperIndex)


### PR DESCRIPTION
## Summary

- expose Windows internals to the test assembly without changing the public API
- use the concrete sorted array type in adaptive heat-scale percentile calculation
- restore a warning-free Windows 1.1.2 build

## Verification

- Core tests: 121/121
- Windows tests: 228/228
- Release build: 0 warnings, 0 errors
- Package identity, publisher, signing workflow, and v1.1.2 tag are unchanged